### PR TITLE
Add missing methods for UTF-8 strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.18.0a2 / 2023-10-17
+## v0.18.0a2 / 2023-10-23
 
 - NEW
   - Add support for [ICU 74](https://github.com/unicode-org/icu/releases/tag/release-74-rc) (partial)
@@ -10,10 +10,17 @@
     - Add `icupy.icu.number.SimpleNumberFormatter` class
     - Add `icupy.icu.USimpleNumberSign` enum
 - ADDED
+  - Add `icupy.icu.Collator.compare_utf8(source: bytes, target: bytes)`
+  - Add `icupy.icu.IDNA.label_to_ascii_utf8(label: bytes, info: IDNAInfo)`
+  - Add `icupy.icu.IDNA.label_to_unicode_utf8(label: bytes, info: IDNAInfo)`
+  - Add `icupy.icu.IDNA.name_to_ascii_utf8(name: bytes, info: IDNAInfo)`
+  - Add `icupy.icu.IDNA.name_to_unicode_utf8(name: bytes, info: IDNAInfo)`
   - Add `icupy.icu.Measure.__ne__(other: UObject)`
   - Add `icupy.icu.MeasureUnit.create_gasoline_energy_density()`
   - Add `icupy.icu.MeasureUnit.get_gasoline_energy_density()`
   - Add `icupy.icu.Normalizer2.get_nfkc_simple_casefold_instance()`
+  - Add `icupy.icu.Normalizer2.is_normalized_utf8(s: bytes)`
+  - Add `icupy.icu.Normalizer2.normalize_utf8(options: int, src: bytes)`
   - Add `icupy.icu.TimeZone.get_iana_id(id_: UnicodeString | str, iana_id: UnicodeString)`
   - Add `icupy.icu.UBlockCode.UBLOCK_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_I`
   - Add `icupy.icu.ULineBreak.U_LB_AKSARA_PREBASE`
@@ -21,6 +28,7 @@
   - Add `icupy.icu.ULineBreak.U_LB_AKSARA`
   - Add `icupy.icu.ULineBreak.U_LB_VIRAMA_FINAL`
   - Add `icupy.icu.ULineBreak.U_LB_VIRAMA`
+  - Add `icupy.icu.UnicodeSet.span_utf8(b: bytes, length: int, span_condition: USetSpanCondition)`
   - Add `icupy.icu.UProperty.UCHAR_ID_COMPAT_MATH_CONTINUE`
   - Add `icupy.icu.UProperty.UCHAR_ID_COMPAT_MATH_START`
   - Add `icupy.icu.UProperty.UCHAR_IDS_UNARY_OPERATOR`

--- a/src/idna.cpp
+++ b/src/idna.cpp
@@ -87,6 +87,20 @@ void init_idna(py::module &m) {
       py::arg("label"), py::arg("dest"), py::arg("info"));
 
   idna.def(
+      "label_to_ascii_utf8",
+      [](const IDNA &self, const py::bytes &label, IDNAInfo &info) {
+        std::string dest;
+        auto sink = StringByteSink<std::string>(&dest);
+        ErrorCode error_code;
+        self.labelToASCII_UTF8(StringPiece(label), sink, info, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return py::bytes(dest);
+      },
+      py::arg("label"), py::arg("info"));
+
+  idna.def(
       "label_to_unicode",
       [](const IDNA &self, const icupy::UnicodeStringVariant &label, UnicodeString &dest,
          IDNAInfo &info) -> UnicodeString & {
@@ -98,6 +112,20 @@ void init_idna(py::module &m) {
         return result;
       },
       py::arg("label"), py::arg("dest"), py::arg("info"));
+
+  idna.def(
+      "label_to_unicode_utf8",
+      [](const IDNA &self, const py::bytes &label, IDNAInfo &info) {
+        std::string dest;
+        auto sink = StringByteSink<std::string>(&dest);
+        ErrorCode error_code;
+        self.labelToUnicodeUTF8(StringPiece(label), sink, info, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return py::bytes(dest);
+      },
+      py::arg("label"), py::arg("info"));
 
   idna.def(
       "name_to_ascii",
@@ -113,6 +141,20 @@ void init_idna(py::module &m) {
       py::arg("name"), py::arg("dest"), py::arg("info"));
 
   idna.def(
+      "name_to_ascii_utf8",
+      [](const IDNA &self, const py::bytes &name, IDNAInfo &info) {
+        std::string dest;
+        auto sink = StringByteSink(&dest);
+        ErrorCode error_code;
+        self.nameToASCII_UTF8(StringPiece(name), sink, info, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return py::bytes(dest);
+      },
+      py::arg("name"), py::arg("info"));
+
+  idna.def(
       "name_to_unicode",
       [](const IDNA &self, const icupy::UnicodeStringVariant &name, UnicodeString &dest,
          IDNAInfo &info) -> UnicodeString & {
@@ -124,6 +166,20 @@ void init_idna(py::module &m) {
         return result;
       },
       py::arg("name"), py::arg("dest"), py::arg("info"));
+
+  idna.def(
+      "name_to_unicode_utf8",
+      [](const IDNA &self, const py::bytes &name, IDNAInfo &info) {
+        std::string dest;
+        auto sink = StringByteSink(&dest);
+        ErrorCode error_code;
+        self.nameToUnicodeUTF8(StringPiece(name), sink, info, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return py::bytes(dest);
+      },
+      py::arg("name"), py::arg("info"));
 
   idna.def_property_readonly_static("ERROR_EMPTY_LABEL",
                                     [](const py::object &) -> int32_t { return UIDNA_ERROR_EMPTY_LABEL; });

--- a/src/normalizer2.cpp
+++ b/src/normalizer2.cpp
@@ -138,6 +138,20 @@ void init_normalizer2(py::module &m) {
       },
       py::arg("s"));
 
+#if (U_ICU_VERSION_MAJOR_NUM >= 60)
+  n2.def(
+      "is_normalized_utf8",
+      [](const Normalizer2 &self, const py::bytes &b) -> py::bool_ {
+        ErrorCode error_code;
+        auto result = self.isNormalizedUTF8(StringPiece(b), error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result;
+      },
+      py::arg("b"));
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 60)
+
   n2.def(
         "normalize",
         [](const Normalizer2 &self, const icupy::UnicodeStringVariant &src) {
@@ -172,6 +186,23 @@ void init_normalizer2(py::module &m) {
         return result;
       },
       py::arg("first"), py::arg("second"));
+
+#if (U_ICU_VERSION_MAJOR_NUM >= 60)
+  // TODO: Implement icu::Edits.
+  n2.def(
+      "normalize_utf8",
+      [](const Normalizer2 &self, uint32_t options, const py::bytes &src) {
+        std::string dest;
+        auto sink = StringByteSink<std::string>(&dest);
+        ErrorCode error_code;
+        self.normalizeUTF8(options, StringPiece(src), sink, nullptr, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return py::bytes(dest);
+      },
+      py::arg("options"), py::arg("src"));
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 60)
 
   n2.def(
       "quick_check",

--- a/src/tblcoll.cpp
+++ b/src/tblcoll.cpp
@@ -129,6 +129,18 @@ void init_tblcoll(py::module &m) {
       */
       ;
 
+  coll.def(
+      "compare_utf8",
+      [](Collator &self, const py::bytes &source, const py::bytes &target) {
+        ErrorCode error_code;
+        auto result = self.compareUTF8(StringPiece(source), StringPiece(target), error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result;
+      },
+      py::arg("source"), py::arg("target"));
+
   coll.def_static(
           "create_instance",
           [](const icupy::LocaleVariant &loc) {

--- a/src/uniset.cpp
+++ b/src/uniset.cpp
@@ -417,6 +417,14 @@ void init_uniset(py::module &m) {
       .def("span", py::overload_cast<const UnicodeString &, int32_t, USetSpanCondition>(&UnicodeSet::span, py::const_),
            py::arg("s"), py::arg("start"), py::arg("span_condition"));
 
+  us.def(
+      "span_utf8",
+      [](const UnicodeSet &self, const py::bytes &b, int32_t length, USetSpanCondition span_condition) {
+        auto s = static_cast<std::string>(b);
+        return self.spanUTF8(s.data(), length, span_condition);
+      },
+      py::arg("b"), py::arg("length"), py::arg("span_condition"));
+
   us.def("span_back",
          py::overload_cast<const char16_t *, int32_t, USetSpanCondition>(&UnicodeSet::spanBack, py::const_),
          py::arg("s"), py::arg("length"), py::arg("span_condition"))

--- a/tests/test_normalizer2.py
+++ b/tests/test_normalizer2.py
@@ -269,6 +269,34 @@ def test_icu_49():
     assert decomposition == UnicodeString("A\\u030A", -1, US_INV).unescape()
 
 
+@pytest.mark.skipif(U_ICU_VERSION_MAJOR_NUM < 60, reason="ICU4C<60")
+def test_icu_60():
+    nfkc_cf = Normalizer2.get_nfkc_casefold_instance()
+    src = (
+        "  AÄA\u0308A\u0308\u00ad\u0323Ä\u0323,"
+        "\u00ad\u1100\u1161가\u11A8가\u3133  "
+    ).encode()
+    expected = "  aääạ\u0308ạ\u0308,가각갃  ".encode()
+
+    # void icu::Normalizer2::normalizeUTF8(
+    #       uint32_t options,
+    #       StringPiece src,
+    #       ByteSink &sink,
+    #       Edits *edits,
+    #       UErrorCode &errorCode
+    # ) const
+    result = nfkc_cf.normalize_utf8(0, src)
+    assert isinstance(result, bytes)
+    assert result == expected
+
+    # UBool icu::Normalizer2::isNormalizedUTF8(
+    #       StringPiece s,
+    #       UErrorCode &errorCode
+    # ) const
+    assert nfkc_cf.is_normalized_utf8(src) is False
+    assert nfkc_cf.is_normalized_utf8(expected) is True
+
+
 @pytest.mark.skipif(U_ICU_VERSION_MAJOR_NUM < 74, reason="ICU4C<74")
 def test_icu_74():
     # static const Normalizer2 *

--- a/tests/test_tblcoll.py
+++ b/tests/test_tblcoll.py
@@ -78,6 +78,15 @@ def test_compare():
     assert coll.compare(source, target, 3) == UCollationResult.UCOL_EQUAL
     assert coll.compare(source, target) == UCollationResult.UCOL_EQUAL
 
+    # UCollationResult icu::Collator::compareUTF8(
+    #       const StringPiece &source,
+    #       const StringPiece &target,
+    #       UErrorCode &status
+    # ) const
+    source = "a\uFFFDz".encode()
+    target = b"a\x80z"
+    assert coll.compare_utf8(source, target) == UCollationResult.UCOL_EQUAL
+
 
 def test_create_collation_element_iterator():
     coll = Collator.create_instance(Locale("es"))

--- a/tests/test_uniset.py
+++ b/tests/test_uniset.py
@@ -872,6 +872,19 @@ def test_span():
         == 2
     )
 
+    # int32_t icu::UnicodeSet::spanUTF8(
+    #       const char *s,
+    #       int32_t length,
+    #       USetSpanCondition spanCondition
+    # ) const
+    b = b"abcde"
+    assert test1.span_utf8(b, -1, USetSpanCondition.USET_SPAN_CONTAINED) == 2
+    assert (
+        test1.span_utf8(b, len(b), USetSpanCondition.USET_SPAN_CONTAINED) == 2
+    )
+    assert test1.span_utf8(b, 2, USetSpanCondition.USET_SPAN_CONTAINED) == 2
+    assert test1.span_utf8(b, 1, USetSpanCondition.USET_SPAN_CONTAINED) == 0
+
 
 def test_span_back():
     test1 = UnicodeSet(UnicodeString("[0-9\u00DF{ab}]"))

--- a/tests/test_uts46.py
+++ b/tests/test_uts46.py
@@ -649,7 +649,7 @@ def test_api():
     #       UnicodeString &dest,
     #       IDNAInfo &info,
     #       UErrorCode &errorCode
-    # )
+    # ) const
     dest = UnicodeString()
     info = IDNAInfo()
     src = UnicodeString("www.eXample.cOm")
@@ -667,12 +667,23 @@ def test_api():
     assert id(result) == id(dest)
     assert dest == expected
 
+    # void icu::IDNA::nameToASCII_UTF8(
+    #   	StringPiece name,
+    #       ByteSink &dest,
+    #       IDNAInfo &info,
+    #       UErrorCode &errorCode
+    # ) const
+    result = _trans.name_to_ascii_utf8(b"www.eXample.cOm", info)
+    assert not info.has_errors()
+    assert isinstance(result, bytes)
+    assert result.decode() == expected
+
     # UnicodeString &icu::IDNA::labelToASCII(
     #       const UnicodeString &label,
     #       UnicodeString &dest,
     #       IDNAInfo &info,
     #       UErrorCode &errorCode
-    # )
+    # ) const
     src.set_to_bogus()
     dest = UnicodeString("quatsch")
     with pytest.raises(ICUError) as exc_info:
@@ -700,12 +711,42 @@ def test_api():
     assert id(result) == id(dest)
     assert dest == expected
 
+    # void icu::IDNA::labelToASCII_UTF8(
+    # 	    StringPiece label,
+    #       ByteSink &dest,
+    #       IDNAInfo &info,
+    #       UErrorCode &errorCode
+    # ) const
+    result = _nontrans.label_to_ascii_utf8(b"xn--bcher.de-65a", info)
+    assert info.get_errors() == (
+        IDNA.ERROR_LABEL_HAS_DOT | IDNA.ERROR_INVALID_ACE_LABEL
+    )
+    assert isinstance(result, bytes)
+    assert result.decode() == expected
+
+    # UnicodeString &icu::IDNA::labelToUnicode(
+    # 	    const UnicodeString &label,
+    #       UnicodeString &dest,
+    #       IDNAInfo &info,
+    #       UErrorCode &errorCode
+    # ) const
     dest.remove()
     result = _trans.label_to_unicode("\x61\u00df", dest, info)
     assert info.get_errors() == 0
     assert isinstance(result, UnicodeString)
     assert id(result) == id(dest)
     assert dest == "\x61\x73\x73"
+
+    # void icu::IDNA::labelToUnicodeUTF8(
+    #   	StringPiece label,
+    #       ByteSink &dest,
+    #       IDNAInfo &info,
+    #       UErrorCode &errorCode
+    # ) const
+    result = _trans.label_to_unicode_utf8(b"\x61\xc3\x9f", info)
+    assert info.get_errors() == 0
+    assert isinstance(result, bytes)
+    assert result == b"\x61\x73\x73"
 
 
 def test_not_std3():
@@ -722,7 +763,7 @@ def test_not_std3():
     #       UnicodeString &dest,
     #       IDNAInfo &info,
     #       UErrorCode &errorCode
-    # )
+    # ) const
     # '\x00a_2+2=4\n.essen.net'
     result = not3.name_to_unicode(src, dest, info)
     assert not info.has_errors()
@@ -731,12 +772,23 @@ def test_not_std3():
     assert result != src
     assert result == expected
 
+    # void icu::IDNA::nameToUnicodeUTF8(
+    #   	StringPiece name,
+    #       ByteSink &dest,
+    #       IDNAInfo &info,
+    #       UErrorCode &errorCode
+    # ) const
+    result = not3.name_to_unicode_utf8(str(src).encode(), info)
+    assert not info.has_errors()
+    assert isinstance(result, bytes)
+    assert result.decode() == str(expected)
+
     # UnicodeString &icu::IDNA::nameToASCII(
     #       const UnicodeString &name,
     #       UnicodeString &dest,
     #       IDNAInfo &info,
     #       UErrorCode &errorCode
-    # )
+    # ) const
     dest.remove()
     src = UnicodeString("a z.xn--4db.edu")
     result = not3.name_to_ascii(src, dest, info)


### PR DESCRIPTION
- Add `icupy.icu.Collator.compare_utf8(source: bytes, target: bytes)`
- Add `icupy.icu.IDNA.label_to_ascii_utf8(label: bytes, info: IDNAInfo)`
- Add `icupy.icu.IDNA.label_to_unicode_utf8(label: bytes, info: IDNAInfo)`
- Add `icupy.icu.IDNA.name_to_ascii_utf8(name: bytes, info: IDNAInfo)`
- Add `icupy.icu.IDNA.name_to_unicode_utf8(name: bytes, info: IDNAInfo)`
- Add `icupy.icu.Normalizer2.is_normalized_utf8(s: bytes)`
- Add `icupy.icu.Normalizer2.normalize_utf8(options: int, src: bytes)`
- Add `icupy.icu.UnicodeSet.span_utf8(b: bytes, length: int, span_condition: USetSpanCondition)`