### PR TITLE
Add support for ICU 75

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: "recursive"
 
       - name: Set up Python ${{matrix.python-version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
 
@@ -75,9 +75,9 @@ jobs:
           pyproject-build --wheel
 
       - name: Store wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist-icupy-icu${{env.icu4c_latest_version}}
+          name: dist-icupy-icu${{env.icu4c_latest_version}}-${{matrix.os}}-${{matrix.python-version}}
           path: dist/*.whl
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           submodules: "recursive"
 
       - name: Set up Python ${{matrix.python-version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
 
@@ -85,9 +85,9 @@ jobs:
 
       - name: Store coverage data
         if: matrix.icu-version == env.icu4c_latest_version
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-${{matrix.os}}-${{matrix.python-version}}
           path: |
             coverage*.info
             .coverage*
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
@@ -118,22 +118,25 @@ jobs:
           sudo apt-get install -y lcov
 
       - name: Restore coverage data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - name: Report coverage statistics
         run: |
           python -m tox -c tox-coverage.ini -e cov,cov-cpp
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
         with:
           fail_ci_if_error: true
           files: coverage.xml, coverage-cpp.info
 
       - name: Store coverage reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-latest]
-        icu-version: ["70.1", "71.1", "72.1", "73.2", "74.2"]
+        icu-version: ["70.1", "71.1", "72.1", "73.2", "74.2", "75rc"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
+        language_version: python3.8
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,28 +11,28 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v17.0.6
+    rev: v18.1.2
     hooks:
     - id: clang-format
       types: [file, c++]
 
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.3.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.0
+    rev: 5.13.2
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.9.0
     hooks:
       - id: mypy

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -33,28 +33,28 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
-                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.2"
+            "version": "==24.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
-                "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
+                "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
+                "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.3.0"
+            "version": "==1.4.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002",
-                "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"
+                "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7",
+                "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==7.4.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==8.1.1"
         }
     }
 }

--- a/icu-versions.json
+++ b/icu-versions.json
@@ -1,6 +1,12 @@
 {
-    "latest": "74.2",
+    "latest": "75rc",
     "versions": [
+        {
+            "version": "75rc",
+            "url": "https://github.com/unicode-org/icu/releases/download/release-75-rc",
+            "icu4c_ubuntu_x64_tgz": "icu4c-75rc-Ubuntu-22.04.x64.tgz",
+            "icu4c_win64_zip": "icu4c-75rc-Win64-MSVC2022.zip"
+        },
         {
             "version": "74.2",
             "url": "https://github.com/unicode-org/icu/releases/download/release-74-2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ source = [
 [tool.black]
 line-length = 79
 target-version = [
-    "py311",
+    "py38",
 ]
 extend-exclude = """
 ^/src/third_party/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = icupy
-version = 0.18.0
+version = 0.19.0.dev1
 description = Python bindings for ICU4C
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/compactdecimalformat.cpp
+++ b/src/compactdecimalformat.cpp
@@ -18,8 +18,7 @@ void init_compactdecimalformat(py::module &m) {
 
   cdf.def("__copy__", &CompactDecimalFormat::clone);
 
-  cdf.def(
-      "__deepcopy__", [](const CompactDecimalFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  cdf.def("__deepcopy__", [](const CompactDecimalFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   cdf.def("clone", &CompactDecimalFormat::clone);
 

--- a/src/currpinf.cpp
+++ b/src/currpinf.cpp
@@ -33,8 +33,7 @@ void init_currpinf(py::module &m) {
 
   cpi.def("__copy__", &CurrencyPluralInfo::clone);
 
-  cpi.def(
-      "__deepcopy__", [](const CurrencyPluralInfo &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  cpi.def("__deepcopy__", [](const CurrencyPluralInfo &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   cpi.def(
       "__eq__", [](const CurrencyPluralInfo &self, const CurrencyPluralInfo &other) { return self == other; },

--- a/src/currunit.cpp
+++ b/src/currunit.cpp
@@ -22,8 +22,7 @@ void init_currunit(py::module &m) {
 
   cu.def("__copy__", &CurrencyUnit::clone);
 
-  cu.def(
-      "__deepcopy__", [](const CurrencyUnit &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  cu.def("__deepcopy__", [](const CurrencyUnit &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   cu.def("clone", &CurrencyUnit::clone);
 

--- a/src/datefmt.cpp
+++ b/src/datefmt.cpp
@@ -307,8 +307,7 @@ void init_datefmt(py::module &m) {
       py::arg("value"));
 #endif // (U_ICU_VERSION_MAJOR_NUM >= 53)
 
-  df.def(
-      "set_lenient", [](DateFormat &self, py::bool_ lenient) { self.setLenient(lenient); }, py::arg("lenient"));
+  df.def("set_lenient", [](DateFormat &self, py::bool_ lenient) { self.setLenient(lenient); }, py::arg("lenient"));
 
   df.def("set_number_format", &DateFormat::setNumberFormat, py::arg("new_number_format"));
 

--- a/src/decimfmt.cpp
+++ b/src/decimfmt.cpp
@@ -61,8 +61,7 @@ void init_decimfmt(py::module & /*m*/, py::class_<DecimalFormat, NumberFormat> &
 
   df.def("__copy__", &DecimalFormat::clone);
 
-  df.def(
-      "__deepcopy__", [](const DecimalFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  df.def("__deepcopy__", [](const DecimalFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   // FIXME: Implement "void icu::DecimalFormat::adoptCurrencyPluralInfo(CurrencyPluralInfo *toAdopt)".
   // FIXME: Implement "void icu::DecimalFormat::adoptDecimalFormatSymbols(DecimalFormatSymbols *symbolsToAdopt)".

--- a/src/dtintrv.cpp
+++ b/src/dtintrv.cpp
@@ -15,8 +15,7 @@ void init_dtintrv(py::module &m) {
 
   di.def("__copy__", &DateInterval::clone);
 
-  di.def(
-      "__deepcopy__", [](const DateInterval &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  di.def("__deepcopy__", [](const DateInterval &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   di.def(
       "__eq__", [](const DateInterval &self, const DateInterval &other) { return self == other; }, py::is_operator(),

--- a/src/dtitvfmt.cpp
+++ b/src/dtitvfmt.cpp
@@ -25,8 +25,7 @@ void init_dtitvfmt(py::module &m) {
 
   fmt.def("__copy__", &DateIntervalFormat::clone);
 
-  fmt.def(
-      "__deepcopy__", [](const DateIntervalFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  fmt.def("__deepcopy__", [](const DateIntervalFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   // FIXME: Implement "void icu::DateIntervalFormat::adoptTimeZone(TimeZone *zoneToAdopt)".
 

--- a/src/dtitvinf.cpp
+++ b/src/dtitvinf.cpp
@@ -24,8 +24,7 @@ void init_dtitvinf(py::module &m) {
 
   dii.def("__copy__", &DateIntervalInfo::clone);
 
-  dii.def(
-      "__deepcopy__", [](const DateIntervalInfo &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  dii.def("__deepcopy__", [](const DateIntervalInfo &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   dii.def(
       "__eq__", [](const DateIntervalInfo &self, const DateIntervalInfo &other) { return self == other; },

--- a/src/dtrule.cpp
+++ b/src/dtrule.cpp
@@ -49,8 +49,7 @@ void init_dtrule(py::module &m) {
 
   dtr.def("__copy__", &DateTimeRule::clone);
 
-  dtr.def(
-      "__deepcopy__", [](const DateTimeRule &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  dtr.def("__deepcopy__", [](const DateTimeRule &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   dtr.def(
       "__eq__", [](const DateTimeRule &self, const DateTimeRule &other) { return self == other; }, py::is_operator(),

--- a/src/fieldpos.cpp
+++ b/src/fieldpos.cpp
@@ -22,8 +22,7 @@ void init_fieldpos(py::module &m) {
 
   fp.def("__copy__", &FieldPosition::clone);
 
-  fp.def(
-      "__deepcopy__", [](const FieldPosition &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  fp.def("__deepcopy__", [](const FieldPosition &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   fp.def(
       "__eq__", [](const FieldPosition &self, const FieldPosition &other) { return self == other; }, py::is_operator(),

--- a/src/fmtable.cpp
+++ b/src/fmtable.cpp
@@ -98,8 +98,7 @@ void init_fmtable(py::module &m, py::class_<Formattable, UObject> &fmt) {
 
   fmt.def("__copy__", &Formattable::clone);
 
-  fmt.def(
-      "__deepcopy__", [](const Formattable &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  fmt.def("__deepcopy__", [](const Formattable &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   fmt.def(
       "__eq__", [](const Formattable &self, const Formattable &other) { return self == other; }, py::is_operator(),

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -12,8 +12,7 @@ void init_format(py::module &m) {
 
   fmt.def("__copy__", &Format::clone);
 
-  fmt.def(
-      "__deepcopy__", [](const Format &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  fmt.def("__deepcopy__", [](const Format &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   fmt.def(
       "__eq__", [](const Format &self, const Format &other) { return self == other; }, py::is_operator(),

--- a/src/gregocal.cpp
+++ b/src/gregocal.cpp
@@ -373,8 +373,7 @@ void init_gregocal(py::module &m) {
   cal.def("set_first_day_of_week", py::overload_cast<UCalendarDaysOfWeek>(&Calendar::setFirstDayOfWeek),
           py::arg("value"));
 
-  cal.def(
-      "set_lenient", [](Calendar &self, py::bool_ lenient) { self.setLenient(lenient); }, py::arg("lenient"));
+  cal.def("set_lenient", [](Calendar &self, py::bool_ lenient) { self.setLenient(lenient); }, py::arg("lenient"));
 
   cal.def("set_minimal_days_in_first_week", &Calendar::setMinimalDaysInFirstWeek, py::arg("value"));
 
@@ -493,8 +492,7 @@ void init_gregocal(py::module &m) {
 
   gc.def("__copy__", &GregorianCalendar::clone);
 
-  gc.def(
-      "__deepcopy__", [](const GregorianCalendar &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  gc.def("__deepcopy__", [](const GregorianCalendar &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   gc.def("__repr__", [](const Calendar &self) {
     std::stringstream ss;

--- a/src/locid.cpp
+++ b/src/locid.cpp
@@ -21,8 +21,7 @@ void init_locid(py::module &m, py::class_<Locale, UObject> &loc) {
 
   loc.def("__copy__", &Locale::clone);
 
-  loc.def(
-      "__deepcopy__", [](const Locale &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  loc.def("__deepcopy__", [](const Locale &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   loc.def(
       "__eq__", [](const Locale &self, const Locale &other) { return self == other; }, py::is_operator(),

--- a/src/measfmt.cpp
+++ b/src/measfmt.cpp
@@ -49,8 +49,7 @@ void init_measfmt(py::module &m) {
 #if (U_ICU_VERSION_MAJOR_NUM >= 53)
   fmt.def("__copy__", &MeasureFormat::clone);
 
-  fmt.def(
-      "__deepcopy__", [](const MeasureFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  fmt.def("__deepcopy__", [](const MeasureFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   fmt.def("clone", &MeasureFormat::clone);
 #endif // (U_ICU_VERSION_MAJOR_NUM >= 53)

--- a/src/measunit.cpp
+++ b/src/measunit.cpp
@@ -80,8 +80,7 @@ void init_measunit(py::module &m) {
 
   mu.def("__copy__", &MeasureUnit::clone);
 
-  mu.def(
-      "__deepcopy__", [](const MeasureUnit &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  mu.def("__deepcopy__", [](const MeasureUnit &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   mu.def(
       "__eq__", [](const MeasureUnit &self, const UObject &other) { return self == other; }, py::is_operator(),

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -27,8 +27,7 @@ void init_measure(py::module &m) {
 
   meas.def("__copy__", &Measure::clone);
 
-  meas.def(
-      "__deepcopy__", [](const Measure &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  meas.def("__deepcopy__", [](const Measure &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   meas.def(
       "__eq__", [](const Measure &self, const UObject &other) { return self == other; }, py::is_operator(),
@@ -73,8 +72,7 @@ void init_measure(py::module &m) {
 
   ca.def("__copy__", &CurrencyAmount::clone);
 
-  ca.def(
-      "__deepcopy__", [](const CurrencyAmount &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  ca.def("__deepcopy__", [](const CurrencyAmount &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   ca.def("clone", &CurrencyAmount::clone);
 
@@ -109,8 +107,7 @@ void init_measure(py::module &m) {
 
   tua.def("__copy__", &TimeUnitAmount::clone);
 
-  tua.def(
-      "__deepcopy__", [](const TimeUnitAmount &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  tua.def("__deepcopy__", [](const TimeUnitAmount &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   tua.def("clone", &TimeUnitAmount::clone);
 

--- a/src/msgfmt.cpp
+++ b/src/msgfmt.cpp
@@ -53,8 +53,7 @@ void init_msgfmt(py::module &m) {
 
   mf.def("__copy__", &MessageFormat::clone);
 
-  mf.def(
-      "__deepcopy__", [](const MessageFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  mf.def("__deepcopy__", [](const MessageFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   // FIXME: Implement "void icu::MessageFormat::adoptFormat(const UnicodeString &formatName, Format *formatToAdopt,
   //  UErrorCode &status)".

--- a/src/numberformatter.cpp
+++ b/src/numberformatter.cpp
@@ -252,6 +252,10 @@ void init_numberformatter(py::module &, py::module &m2) {
   });
 #endif // (U_ICU_VERSION_MAJOR_NUM >= 62)
 
+#if (U_ICU_VERSION_MAJOR_NUM >= 75)
+  lnf.def("without_locale", [](const LocalizedNumberFormatter &self) { return self.withoutLocale(); });
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 75)
+
   //
   // icu::number::NumberFormatter
   //

--- a/src/numberrangeformatter.cpp
+++ b/src/numberrangeformatter.cpp
@@ -112,6 +112,10 @@ void init_numberrangeformatter(py::module &, py::module &m2) {
       },
       py::arg("first"), py::arg("second"));
 
+#if (U_ICU_VERSION_MAJOR_NUM >= 75)
+  lnrf.def("without_locale", [](const LocalizedNumberRangeFormatter &self) { return self.withoutLocale(); });
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 75)
+
   //
   // icu::number::NumberRangeFormatter
   //

--- a/src/numfmt.cpp
+++ b/src/numfmt.cpp
@@ -67,8 +67,7 @@ void init_numfmt(py::module & /*m*/, py::class_<NumberFormat, Format> &nf) {
   //
   nf.def("__copy__", &NumberFormat::clone);
 
-  nf.def(
-      "___deepcopy__", [](const NumberFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  nf.def("___deepcopy__", [](const NumberFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   nf.def("clone", &NumberFormat::clone);
 
@@ -393,8 +392,7 @@ void init_numfmt(py::module & /*m*/, py::class_<NumberFormat, Format> &nf) {
       "set_grouping_used", [](NumberFormat &self, py::bool_ new_value) { self.setGroupingUsed(new_value); },
       py::arg("new_value"));
 
-  nf.def(
-      "set_lenient", [](NumberFormat &self, py::bool_ enable) { self.setLenient(enable); }, py::arg("enable"));
+  nf.def("set_lenient", [](NumberFormat &self, py::bool_ enable) { self.setLenient(enable); }, py::arg("enable"));
 
   nf.def("set_maximum_fraction_digits", &NumberFormat::setMaximumFractionDigits, py::arg("new_value"));
 

--- a/src/parsepos.cpp
+++ b/src/parsepos.cpp
@@ -17,8 +17,7 @@ void init_parsepos(py::module &m) {
 
   pp.def("__copy__", &ParsePosition::clone);
 
-  pp.def(
-      "__deepcopy__", [](const ParsePosition &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  pp.def("__deepcopy__", [](const ParsePosition &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   pp.def(
       "__eq__", [](const ParsePosition &self, const ParsePosition &other) { return self == other; }, py::is_operator(),

--- a/src/plurfmt.cpp
+++ b/src/plurfmt.cpp
@@ -130,8 +130,7 @@ void init_plurfmt(py::module &m) {
 
   pf.def("__copy__", &PluralFormat::clone);
 
-  pf.def(
-      "___deepcopy__", [](const PluralFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  pf.def("___deepcopy__", [](const PluralFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   pf.def(
       "apply_pattern",

--- a/src/plurrule.cpp
+++ b/src/plurrule.cpp
@@ -33,8 +33,7 @@ void init_plurrule(py::module &, py::class_<PluralRules, UObject> &pr) {
 
   pr.def("__copy__", py::overload_cast<>(&PluralRules::clone, py::const_));
 
-  pr.def(
-      "__deepcopy__", [](const PluralRules &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  pr.def("__deepcopy__", [](const PluralRules &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   pr.def(
       "__eq__", [](const PluralRules &self, const PluralRules &other) { return self == other; }, py::is_operator(),

--- a/src/rbbi.cpp
+++ b/src/rbbi.cpp
@@ -21,8 +21,7 @@ void init_rbbi(py::module &m) {
 
   bi.def("__copy__", &BreakIterator::clone);
 
-  bi.def(
-      "__deepcopy__", [](const BreakIterator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  bi.def("__deepcopy__", [](const BreakIterator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   bi.def(
       "__eq__", [](const BreakIterator &self, const BreakIterator &other) { return self == other; }, py::is_operator(),

--- a/src/rbnf.cpp
+++ b/src/rbnf.cpp
@@ -85,8 +85,7 @@ void init_rbnf(py::module &m) {
 
   rbnf.def("__copy__", &RuleBasedNumberFormat::clone);
 
-  rbnf.def(
-      "__deepcopy__", [](const RuleBasedNumberFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  rbnf.def("__deepcopy__", [](const RuleBasedNumberFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   // FIXME: Implement "void icu::RuleBasedNumberFormat::adoptDecimalFormatSymbols(DecimalFormatSymbols
   //  *symbolsToAdopt)".

--- a/src/regex.cpp
+++ b/src/regex.cpp
@@ -577,8 +577,7 @@ void init_regex(py::module &m) {
 
   rp.def("__copy__", &RegexPattern::clone);
 
-  rp.def(
-      "__deepcopy__", [](const RegexPattern &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  rp.def("__deepcopy__", [](const RegexPattern &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   rp.def(
       "__eq__", [](const RegexPattern &self, const RegexPattern &other) { return self == other; }, py::is_operator(),

--- a/src/resbund.cpp
+++ b/src/resbund.cpp
@@ -72,8 +72,7 @@ void init_resbund(py::module &m) {
 
   res.def("__copy__", &ResourceBundle::clone);
 
-  res.def(
-      "__deepcopy__", [](const ResourceBundle &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  res.def("__deepcopy__", [](const ResourceBundle &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   res.def("__iter__", [](ResourceBundle &self) -> ResourceBundle & {
     self.resetIterator();

--- a/src/schriter.cpp
+++ b/src/schriter.cpp
@@ -131,8 +131,7 @@ void init_schriter(py::module &m) {
 
   uci.def("__copy__", &UCharCharacterIterator::clone);
 
-  uci.def(
-      "__deepcopy__", [](const UCharCharacterIterator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  uci.def("__deepcopy__", [](const UCharCharacterIterator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   uci.def("clone", &UCharCharacterIterator::clone);
 

--- a/src/selfmt.cpp
+++ b/src/selfmt.cpp
@@ -23,8 +23,7 @@ void init_selfmt(py::module &m) {
 
   sf.def("__copy__", &SelectFormat::clone);
 
-  sf.def(
-      "___deepcopy__", [](const SelectFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  sf.def("___deepcopy__", [](const SelectFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   sf.def(
       "apply_pattern",

--- a/src/simplenumberformatter.cpp
+++ b/src/simplenumberformatter.cpp
@@ -60,6 +60,19 @@ void init_simplenumberformatter(py::module & /*m*/, py::module &m2) {
       },
       py::arg("power"), py::arg("rounding_mode"));
 
+#if (U_ICU_VERSION_MAJOR_NUM >= 75)
+  sn.def(
+      "set_maximum_integer_digits",
+      [](SimpleNumber &self, uint32_t maximum_integer_digits) {
+        ErrorCode error_code;
+        self.setMaximumIntegerDigits(maximum_integer_digits, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+      },
+      py::arg("maximum_integer_digits"));
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 75)
+
   sn.def(
       "set_minimum_fraction_digits",
       [](SimpleNumber &self, uint32_t minimum_fraction_digits) {

--- a/src/smpdtfmt.cpp
+++ b/src/smpdtfmt.cpp
@@ -86,8 +86,7 @@ void init_smpdtfmt(py::module &m) {
 
   sdf.def("__copy__", &SimpleDateFormat::clone);
 
-  sdf.def(
-      "__deepcopy__", [](const SimpleDateFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  sdf.def("__deepcopy__", [](const SimpleDateFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   // FIXME: Implement "void icu::SimpleDateFormat::adoptCalendar(Calendar *calendarToAdopt)".
   // FIXME: Implement "void icu::SimpleDateFormat::adoptDateFormatSymbols(DateFormatSymbols *newFormatSymbols)".

--- a/src/strenum.cpp
+++ b/src/strenum.cpp
@@ -12,8 +12,7 @@ void init_strenum(py::module &m) {
 
   se.def("__copy__", &StringEnumeration::clone);
 
-  se.def(
-      "__deepcopy__", [](const StringEnumeration &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  se.def("__deepcopy__", [](const StringEnumeration &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   se.def(
       "__eq__", [](const StringEnumeration &self, const StringEnumeration &other) { return self == other; },

--- a/src/stsearch.cpp
+++ b/src/stsearch.cpp
@@ -275,8 +275,7 @@ void init_stsearch(py::module &m) {
 
   ss.def("__copy__", &StringSearch::clone);
 
-  ss.def(
-      "__deepcopy__", [](const StringSearch &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  ss.def("__deepcopy__", [](const StringSearch &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   ss.def("clone", &StringSearch::clone);
 

--- a/src/tblcoll.cpp
+++ b/src/tblcoll.cpp
@@ -58,8 +58,7 @@ void init_tblcoll(py::module &m) {
   //
   coll.def("__copy__", &Collator::clone);
 
-  coll.def(
-      "__deepcopy__", [](const Collator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  coll.def("__deepcopy__", [](const Collator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   coll.def(
       "__eq__", [](const Collator &self, const Collator &other) { return self == other; }, py::is_operator(),
@@ -488,8 +487,7 @@ void init_tblcoll(py::module &m) {
 
   rbc.def("__copy__", &RuleBasedCollator::clone);
 
-  rbc.def(
-      "__deepcopy__", [](const RuleBasedCollator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  rbc.def("__deepcopy__", [](const RuleBasedCollator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   rbc.def("clone", &RuleBasedCollator::clone);
 

--- a/src/timezone.cpp
+++ b/src/timezone.cpp
@@ -59,8 +59,7 @@ void init_timezone(py::module &m) {
   //
   tz.def("__copy__", &TimeZone::clone);
 
-  tz.def(
-      "__deepcopy__", [](const TimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  tz.def("__deepcopy__", [](const TimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   tz.def(
       "__eq__", [](const TimeZone &self, const TimeZone &other) { return self == other; }, py::is_operator(),
@@ -353,8 +352,7 @@ void init_timezone(py::module &m) {
   //
   btz.def("__copy__", &BasicTimeZone::clone);
 
-  btz.def(
-      "__deepcopy__", [](const BasicTimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  btz.def("__deepcopy__", [](const BasicTimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   btz.def("clone", &BasicTimeZone::clone);
 
@@ -451,8 +449,7 @@ void init_timezone(py::module &m) {
 
   rbtz.def("__copy__", &RuleBasedTimeZone::clone);
 
-  rbtz.def(
-      "__deepcopy__", [](const RuleBasedTimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  rbtz.def("__deepcopy__", [](const RuleBasedTimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   rbtz.def(
       "add_transition_rule",
@@ -559,8 +556,7 @@ void init_timezone(py::module &m) {
 
   stz.def("__copy__", &SimpleTimeZone::clone);
 
-  stz.def(
-      "__deepcopy__", [](const SimpleTimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  stz.def("__deepcopy__", [](const SimpleTimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   stz.def("clone", &SimpleTimeZone::clone);
 
@@ -786,8 +782,7 @@ void init_timezone(py::module &m) {
 
   vtz.def("__copy__", &VTimeZone::clone);
 
-  vtz.def(
-      "__deepcopy__", [](const VTimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  vtz.def("__deepcopy__", [](const VTimeZone &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   vtz.def("clone", &VTimeZone::clone);
 

--- a/src/tmunit.cpp
+++ b/src/tmunit.cpp
@@ -30,8 +30,7 @@ void init_tmunit(py::module &m) {
 
   tu.def("__copy__", &TimeUnit::clone);
 
-  tu.def(
-      "__deepcopy__", [](const TimeUnit &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  tu.def("__deepcopy__", [](const TimeUnit &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   tu.def("clone", &TimeUnit::clone);
 

--- a/src/translit.cpp
+++ b/src/translit.cpp
@@ -60,8 +60,7 @@ void init_translit(py::module &m) {
 
   tl.def("__copy__", &Transliterator::clone);
 
-  tl.def(
-      "__deepcopy__", [](const Transliterator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  tl.def("__deepcopy__", [](const Transliterator &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   tl.def(
       "adopt_filter",

--- a/src/tzfmt.cpp
+++ b/src/tzfmt.cpp
@@ -134,8 +134,7 @@ void init_tzfmt(py::module &m) {
 
   tzf.def("__copy__", &TimeZoneFormat::clone);
 
-  tzf.def(
-      "__deepcopy__", [](const TimeZoneFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  tzf.def("__deepcopy__", [](const TimeZoneFormat &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   // FIXME: Implement "void icu::TimeZoneFormat::adoptTimeZoneNames(TimeZoneNames *tznames)".
 

--- a/src/tznames.cpp
+++ b/src/tznames.cpp
@@ -38,8 +38,7 @@ void init_tznames(py::module &m) {
 
   tzn.def("__copy__", &TimeZoneNames::clone);
 
-  tzn.def(
-      "__deepcopy__", [](const TimeZoneNames &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  tzn.def("__deepcopy__", [](const TimeZoneNames &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   tzn.def(
       "__eq__", [](const TimeZoneNames &self, const TimeZoneNames &other) { return self == other; }, py::is_operator(),

--- a/src/tzrule.cpp
+++ b/src/tzrule.cpp
@@ -15,8 +15,7 @@ void init_tzrule(py::module &m) {
 
   tzr.def("__copy__", &TimeZoneRule::clone);
 
-  tzr.def(
-      "__deepcopy__", [](const TimeZoneRule &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  tzr.def("__deepcopy__", [](const TimeZoneRule &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   tzr.def(
       "__eq__", [](const TimeZoneRule &self, const TimeZoneRule &other) { return self == other; }, py::is_operator(),
@@ -98,8 +97,7 @@ void init_tzrule(py::module &m) {
 
   atzr.def("__copy__", &AnnualTimeZoneRule::clone);
 
-  atzr.def(
-      "__deepcopy__", [](const AnnualTimeZoneRule &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  atzr.def("__deepcopy__", [](const AnnualTimeZoneRule &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   atzr.def("__repr__", [](const AnnualTimeZoneRule &self) {
     std::stringstream ss;
@@ -147,8 +145,7 @@ void init_tzrule(py::module &m) {
 
   itzr.def("__copy__", &InitialTimeZoneRule::clone);
 
-  itzr.def(
-      "__deepcopy__", [](const InitialTimeZoneRule &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  itzr.def("__deepcopy__", [](const InitialTimeZoneRule &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   itzr.def("__repr__", [](const InitialTimeZoneRule &self) {
     std::stringstream ss;

--- a/src/tztrans.cpp
+++ b/src/tztrans.cpp
@@ -18,8 +18,7 @@ void init_tztrans(py::module &m) {
 
   tzt.def("__copy__", &TimeZoneTransition::clone);
 
-  tzt.def(
-      "__deepcopy__", [](const TimeZoneTransition &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  tzt.def("__deepcopy__", [](const TimeZoneTransition &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   tzt.def(
       "__eq__", [](const TimeZoneTransition &self, const TimeZoneTransition &other) { return self == other; },

--- a/src/ubidi.cpp
+++ b/src/ubidi.cpp
@@ -168,11 +168,9 @@ void init_ubidi(py::module &m) {
   //
   // Functions
   //
-  m.def(
-      "ubidi_close", [](_UBiDiPtr &bidi) { ubidi_close(bidi); }, py::arg("bidi"));
+  m.def("ubidi_close", [](_UBiDiPtr &bidi) { ubidi_close(bidi); }, py::arg("bidi"));
 
-  m.def(
-      "ubidi_count_paragraphs", [](_UBiDiPtr &bidi) { return ubidi_countParagraphs(bidi); }, py::arg("bidi"));
+  m.def("ubidi_count_paragraphs", [](_UBiDiPtr &bidi) { return ubidi_countParagraphs(bidi); }, py::arg("bidi"));
 
   m.def(
       "ubidi_count_runs",
@@ -209,11 +207,9 @@ void init_ubidi(py::module &m) {
       "ubidi_get_customized_class", [](_UBiDiPtr &bidi, UChar32 c) { return ubidi_getCustomizedClass(bidi, c); },
       py::arg("bidi"), py::arg("c"));
 
-  m.def(
-      "ubidi_get_direction", [](_UBiDiPtr &bidi) { return ubidi_getDirection(bidi); }, py::arg("bidi"));
+  m.def("ubidi_get_direction", [](_UBiDiPtr &bidi) { return ubidi_getDirection(bidi); }, py::arg("bidi"));
 
-  m.def(
-      "ubidi_get_length", [](_UBiDiPtr &bidi) { return ubidi_getLength(bidi); }, py::arg("bidi"));
+  m.def("ubidi_get_length", [](_UBiDiPtr &bidi) { return ubidi_getLength(bidi); }, py::arg("bidi"));
 
   m.def(
       "ubidi_get_level_at", [](_UBiDiPtr &bidi, int32_t char_index) { return ubidi_getLevelAt(bidi, char_index); },
@@ -301,21 +297,17 @@ void init_ubidi(py::module &m) {
       },
       py::arg("bidi"), py::arg("para_index"));
 
-  m.def(
-      "ubidi_get_para_level", [](_UBiDiPtr &bidi) { return ubidi_getParaLevel(bidi); }, py::arg("bidi"));
+  m.def("ubidi_get_para_level", [](_UBiDiPtr &bidi) { return ubidi_getParaLevel(bidi); }, py::arg("bidi"));
 
-  m.def(
-      "ubidi_get_processed_length", [](_UBiDiPtr &bidi) { return ubidi_getProcessedLength(bidi); }, py::arg("bidi"));
+  m.def("ubidi_get_processed_length", [](_UBiDiPtr &bidi) { return ubidi_getProcessedLength(bidi); }, py::arg("bidi"));
 
-  m.def(
-      "ubidi_get_reordering_mode", [](_UBiDiPtr &bidi) { return ubidi_getReorderingMode(bidi); }, py::arg("bidi"));
+  m.def("ubidi_get_reordering_mode", [](_UBiDiPtr &bidi) { return ubidi_getReorderingMode(bidi); }, py::arg("bidi"));
 
   m.def(
       "ubidi_get_reordering_options", [](_UBiDiPtr &bidi) { return ubidi_getReorderingOptions(bidi); },
       py::arg("bidi"));
 
-  m.def(
-      "ubidi_get_result_length", [](_UBiDiPtr &bidi) { return ubidi_getResultLength(bidi); }, py::arg("bidi"));
+  m.def("ubidi_get_result_length", [](_UBiDiPtr &bidi) { return ubidi_getResultLength(bidi); }, py::arg("bidi"));
 
   m.def(
       "ubidi_get_text", [](_UBiDiPtr &bidi) { return ubidi_getText(bidi); }, py::return_value_policy::reference,
@@ -368,8 +360,7 @@ void init_ubidi(py::module &m) {
       },
       py::arg("src_map"), py::arg("length"));
 
-  m.def(
-      "ubidi_is_inverse", [](_UBiDiPtr &bidi) -> py::bool_ { return ubidi_isInverse(bidi); }, py::arg("bidi"));
+  m.def("ubidi_is_inverse", [](_UBiDiPtr &bidi) -> py::bool_ { return ubidi_isInverse(bidi); }, py::arg("bidi"));
 
   m.def(
       "ubidi_is_order_paragraphs_ltr", [](_UBiDiPtr &bidi) -> py::bool_ { return ubidi_isOrderParagraphsLTR(bidi); },

--- a/src/uchar.cpp
+++ b/src/uchar.cpp
@@ -1429,11 +1429,9 @@ void init_uchar(py::module &m) {
   //
   // Functions
   //
-  m.def(
-      "u_get_gc_mask", [](UChar32 c) { return U_GET_GC_MASK(c); }, py::arg("c"));
+  m.def("u_get_gc_mask", [](UChar32 c) { return U_GET_GC_MASK(c); }, py::arg("c"));
 
-  m.def(
-      "u_mask", [](UChar32 c) { return U_MASK(c); }, py::arg("c"));
+  m.def("u_mask", [](UChar32 c) { return U_MASK(c); }, py::arg("c"));
 
   m.def(
       "u_char_age",
@@ -1568,89 +1566,61 @@ void init_uchar(py::module &m) {
       "u_has_binary_property", [](UChar32 c, UProperty which) -> py::bool_ { return u_hasBinaryProperty(c, which); },
       py::arg("c"), py::arg("which"));
 
-  m.def(
-      "u_isalnum", [](UChar32 c) -> py::bool_ { return u_isalnum(c); }, py::arg("c"));
+  m.def("u_isalnum", [](UChar32 c) -> py::bool_ { return u_isalnum(c); }, py::arg("c"));
 
-  m.def(
-      "u_isalpha", [](UChar32 c) -> py::bool_ { return u_isalpha(c); }, py::arg("c"));
+  m.def("u_isalpha", [](UChar32 c) -> py::bool_ { return u_isalpha(c); }, py::arg("c"));
 
-  m.def(
-      "u_isbase", [](UChar32 c) -> py::bool_ { return u_isbase(c); }, py::arg("c"));
+  m.def("u_isbase", [](UChar32 c) -> py::bool_ { return u_isbase(c); }, py::arg("c"));
 
-  m.def(
-      "u_isblank", [](UChar32 c) -> py::bool_ { return u_isblank(c); }, py::arg("c"));
+  m.def("u_isblank", [](UChar32 c) -> py::bool_ { return u_isblank(c); }, py::arg("c"));
 
-  m.def(
-      "u_iscntrl", [](UChar32 c) -> py::bool_ { return u_iscntrl(c); }, py::arg("c"));
+  m.def("u_iscntrl", [](UChar32 c) -> py::bool_ { return u_iscntrl(c); }, py::arg("c"));
 
-  m.def(
-      "u_isdefined", [](UChar32 c) -> py::bool_ { return u_isdefined(c); }, py::arg("c"));
+  m.def("u_isdefined", [](UChar32 c) -> py::bool_ { return u_isdefined(c); }, py::arg("c"));
 
-  m.def(
-      "u_isdigit", [](UChar32 c) -> py::bool_ { return u_isdigit(c); }, py::arg("c"));
+  m.def("u_isdigit", [](UChar32 c) -> py::bool_ { return u_isdigit(c); }, py::arg("c"));
 
-  m.def(
-      "u_isgraph", [](UChar32 c) -> py::bool_ { return u_isgraph(c); }, py::arg("c"));
+  m.def("u_isgraph", [](UChar32 c) -> py::bool_ { return u_isgraph(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_id_ignorable", [](UChar32 c) -> py::bool_ { return u_isIDIgnorable(c); }, py::arg("c"));
+  m.def("u_is_id_ignorable", [](UChar32 c) -> py::bool_ { return u_isIDIgnorable(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_id_part", [](UChar32 c) -> py::bool_ { return u_isIDPart(c); }, py::arg("c"));
+  m.def("u_is_id_part", [](UChar32 c) -> py::bool_ { return u_isIDPart(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_id_start", [](UChar32 c) -> py::bool_ { return u_isIDStart(c); }, py::arg("c"));
+  m.def("u_is_id_start", [](UChar32 c) -> py::bool_ { return u_isIDStart(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_iso_control", [](UChar32 c) -> py::bool_ { return u_isISOControl(c); }, py::arg("c"));
+  m.def("u_is_iso_control", [](UChar32 c) -> py::bool_ { return u_isISOControl(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_java_id_part", [](UChar32 c) -> py::bool_ { return u_isJavaIDPart(c); }, py::arg("c"));
+  m.def("u_is_java_id_part", [](UChar32 c) -> py::bool_ { return u_isJavaIDPart(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_java_id_start", [](UChar32 c) -> py::bool_ { return u_isJavaIDStart(c); }, py::arg("c"));
+  m.def("u_is_java_id_start", [](UChar32 c) -> py::bool_ { return u_isJavaIDStart(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_java_space_char", [](UChar32 c) -> py::bool_ { return u_isJavaSpaceChar(c); }, py::arg("c"));
+  m.def("u_is_java_space_char", [](UChar32 c) -> py::bool_ { return u_isJavaSpaceChar(c); }, py::arg("c"));
 
-  m.def(
-      "u_islower", [](UChar32 c) -> py::bool_ { return u_islower(c); }, py::arg("c"));
+  m.def("u_islower", [](UChar32 c) -> py::bool_ { return u_islower(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_mirrored", [](UChar32 c) -> py::bool_ { return u_isMirrored(c); }, py::arg("c"));
+  m.def("u_is_mirrored", [](UChar32 c) -> py::bool_ { return u_isMirrored(c); }, py::arg("c"));
 
-  m.def(
-      "u_isprint", [](UChar32 c) -> py::bool_ { return u_isprint(c); }, py::arg("c"));
+  m.def("u_isprint", [](UChar32 c) -> py::bool_ { return u_isprint(c); }, py::arg("c"));
 
-  m.def(
-      "u_ispunct", [](UChar32 c) -> py::bool_ { return u_ispunct(c); }, py::arg("c"));
+  m.def("u_ispunct", [](UChar32 c) -> py::bool_ { return u_ispunct(c); }, py::arg("c"));
 
-  m.def(
-      "u_isspace", [](UChar32 c) -> py::bool_ { return u_isspace(c); }, py::arg("c"));
+  m.def("u_isspace", [](UChar32 c) -> py::bool_ { return u_isspace(c); }, py::arg("c"));
 
-  m.def(
-      "u_istitle", [](UChar32 c) -> py::bool_ { return u_istitle(c); }, py::arg("c"));
+  m.def("u_istitle", [](UChar32 c) -> py::bool_ { return u_istitle(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_ualphabetic", [](UChar32 c) -> py::bool_ { return u_isUAlphabetic(c); }, py::arg("c"));
+  m.def("u_is_ualphabetic", [](UChar32 c) -> py::bool_ { return u_isUAlphabetic(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_ulowercase", [](UChar32 c) -> py::bool_ { return u_isULowercase(c); }, py::arg("c"));
+  m.def("u_is_ulowercase", [](UChar32 c) -> py::bool_ { return u_isULowercase(c); }, py::arg("c"));
 
-  m.def(
-      "u_isupper", [](UChar32 c) -> py::bool_ { return u_isupper(c); }, py::arg("c"));
+  m.def("u_isupper", [](UChar32 c) -> py::bool_ { return u_isupper(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_uuppercase", [](UChar32 c) -> py::bool_ { return u_isUUppercase(c); }, py::arg("c"));
+  m.def("u_is_uuppercase", [](UChar32 c) -> py::bool_ { return u_isUUppercase(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_uwhite_space", [](UChar32 c) -> py::bool_ { return u_isUWhiteSpace(c); }, py::arg("c"));
+  m.def("u_is_uwhite_space", [](UChar32 c) -> py::bool_ { return u_isUWhiteSpace(c); }, py::arg("c"));
 
-  m.def(
-      "u_is_whitespace", [](UChar32 c) -> py::bool_ { return u_isWhitespace(c); }, py::arg("c"));
+  m.def("u_is_whitespace", [](UChar32 c) -> py::bool_ { return u_isWhitespace(c); }, py::arg("c"));
 
-  m.def(
-      "u_isxdigit", [](UChar32 c) -> py::bool_ { return u_isxdigit(c); }, py::arg("c"));
+  m.def("u_isxdigit", [](UChar32 c) -> py::bool_ { return u_isxdigit(c); }, py::arg("c"));
 
 #if (U_ICU_VERSION_MAJOR_NUM >= 70)
   m.def(

--- a/src/uchar.cpp
+++ b/src/uchar.cpp
@@ -597,6 +597,38 @@ void init_uchar(py::module &m) {
 #endif // U_HIDE_DEPRECATED_API
       .export_values();
 
+#if (U_ICU_VERSION_MAJOR_NUM >= 75)
+  //
+  // UIdentifierStatus
+  //
+  py::enum_<UIdentifierStatus>(m, "UIdentifierStatus", py::arithmetic(),
+                               "Identifier Status constants.\n\n"
+                               "See https://www.unicode.org/reports/tr39/#Identifier_Status_and_Type.")
+      .value("U_ID_STATUS_RESTRICTED", U_ID_STATUS_RESTRICTED)
+      .value("U_ID_STATUS_ALLOWED", U_ID_STATUS_ALLOWED)
+      .export_values();
+
+  //
+  // UIdentifierType
+  //
+  py::enum_<UIdentifierType>(m, "UIdentifierType", py::arithmetic(),
+                             "Identifier Type constants.\n\n"
+                             "See https://www.unicode.org/reports/tr39/#Identifier_Status_and_Type.")
+      .value("U_ID_TYPE_NOT_CHARACTER", U_ID_TYPE_NOT_CHARACTER)
+      .value("U_ID_TYPE_DEPRECATED", U_ID_TYPE_DEPRECATED)
+      .value("U_ID_TYPE_DEFAULT_IGNORABLE", U_ID_TYPE_DEFAULT_IGNORABLE)
+      .value("U_ID_TYPE_NOT_NFKC", U_ID_TYPE_NOT_NFKC)
+      .value("U_ID_TYPE_NOT_XID", U_ID_TYPE_NOT_XID)
+      .value("U_ID_TYPE_EXCLUSION", U_ID_TYPE_EXCLUSION)
+      .value("U_ID_TYPE_OBSOLETE", U_ID_TYPE_OBSOLETE)
+      .value("U_ID_TYPE_TECHNICAL", U_ID_TYPE_TECHNICAL)
+      .value("U_ID_TYPE_UNCOMMON_USE", U_ID_TYPE_UNCOMMON_USE)
+      .value("U_ID_TYPE_LIMITED_USE", U_ID_TYPE_LIMITED_USE)
+      .value("U_ID_TYPE_INCLUSION", U_ID_TYPE_INCLUSION)
+      .value("U_ID_TYPE_RECOMMENDED", U_ID_TYPE_RECOMMENDED)
+      .export_values();
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 75)
+
 #if (U_ICU_VERSION_MAJOR_NUM >= 63)
   //
   // UIndicPositionalCategory
@@ -1243,6 +1275,12 @@ void init_uchar(py::module &m) {
              "Used for UAX #50 Unicode Vertical Text Layout (https://www.unicode.org/reports/tr50/). New as a UCD "
              "property in Unicode 10.0.")
 #endif // (U_ICU_VERSION_MAJOR_NUM >= 63)
+#if (U_ICU_VERSION_MAJOR_NUM >= 75)
+      .value("UCHAR_IDENTIFIER_STATUS", UCHAR_IDENTIFIER_STATUS,
+             "Enumerated property Identifier_Status.\n\n"
+             "Used for UTS #39 General Security Profile for Identifiers "
+             "(https://www.unicode.org/reports/tr39/#General_Security_Profile).")
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 75)
 #ifndef U_HIDE_DEPRECATED_API
       .value("UCHAR_INT_LIMIT", UCHAR_INT_LIMIT,
              "**Deprecated:** ICU 58 The numeric value may change over time, see ICU ticket #12420.")
@@ -1321,6 +1359,14 @@ void init_uchar(py::module &m) {
              "*uscript_get_script_extensions* in uscript.h.")
       .value("UCHAR_OTHER_PROPERTY_START", UCHAR_OTHER_PROPERTY_START,
              "First constant for Unicode properties with unusual value types.")
+#if (U_ICU_VERSION_MAJOR_NUM >= 75)
+      .value("UCHAR_IDENTIFIER_TYPE", UCHAR_IDENTIFIER_TYPE,
+             "Miscellaneous property Identifier_Type.\n\n"
+             "Used for UTS #39 General Security Profile for Identifiers "
+             "(https://www.unicode.org/reports/tr39/#General_Security_Profile).\n\n"
+             "Corresponds to *u_has_id_type()* and *u_get_id_types()*.\n\n"
+             "Each code point maps to a <i>set</i> of *UIdentifierType* values.")
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 75)
 #ifndef U_HIDE_DEPRECATED_API
       .value("UCHAR_OTHER_PROPERTY_LIMIT", UCHAR_OTHER_PROPERTY_LIMIT,
              "**Deprecated:** ICU 58 The numeric value may change over time, see ICU ticket #12420.")
@@ -1521,6 +1567,29 @@ void init_uchar(py::module &m) {
       },
       py::arg("c"));
 
+#if (U_ICU_VERSION_MAJOR_NUM >= 75)
+  m.def(
+      "u_get_id_types",
+      [](UChar32 c) {
+        int32_t size = 8;
+        std::vector<UIdentifierType> result(size);
+        ErrorCode error_code;
+        do {
+          error_code.reset();
+          size = u_getIDTypes(c, result.data(), static_cast<int32_t>(result.capacity()), error_code);
+          if (error_code == U_BUFFER_OVERFLOW_ERROR) {
+            result.reserve(size + 1);
+          }
+          result.resize(size);
+        } while (error_code == U_BUFFER_OVERFLOW_ERROR);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result;
+      },
+      py::arg("c"));
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 75)
+
 #if (U_ICU_VERSION_MAJOR_NUM >= 63)
   m.def(
       "u_get_int_property_map",
@@ -1565,6 +1634,12 @@ void init_uchar(py::module &m) {
   m.def(
       "u_has_binary_property", [](UChar32 c, UProperty which) -> py::bool_ { return u_hasBinaryProperty(c, which); },
       py::arg("c"), py::arg("which"));
+
+#if (U_ICU_VERSION_MAJOR_NUM >= 75)
+  m.def(
+      "u_has_id_type", [](UChar32 c, UIdentifierType type) { return u_hasIDType(c, type); }, py::arg("c"),
+      py::arg("type_"));
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 75)
 
   m.def("u_isalnum", [](UChar32 c) -> py::bool_ { return u_isalnum(c); }, py::arg("c"));
 

--- a/src/ucnv.cpp
+++ b/src/ucnv.cpp
@@ -93,8 +93,7 @@ void init_ucnv(py::module &m) {
       py::arg("cnv"));
 #endif // (U_ICU_VERSION_MAJOR_NUM >= 71)
 
-  m.def(
-      "ucnv_close", [](_UConverterPtr &converter) { ucnv_close(converter); }, py::arg("converter"));
+  m.def("ucnv_close", [](_UConverterPtr &converter) { ucnv_close(converter); }, py::arg("converter"));
 
   m.def("ucnv_compare_names", &ucnv_compareNames, py::arg("name1"), py::arg("name2"));
 
@@ -350,8 +349,7 @@ void init_ucnv(py::module &m) {
       },
       py::return_value_policy::reference, py::arg("converter"));
 
-  m.def(
-      "ucnv_get_type", [](const _UConverterPtr &converter) { return ucnv_getType(converter); }, py::arg("converter"));
+  m.def("ucnv_get_type", [](const _UConverterPtr &converter) { return ucnv_getType(converter); }, py::arg("converter"));
 
   m.def(
       "ucnv_get_unicode_set",
@@ -437,8 +435,7 @@ void init_ucnv(py::module &m) {
       },
       py::arg("conv_name"), py::arg("standard"));
 
-  m.def(
-      "ucnv_reset", [](_UConverterPtr &converter) { ucnv_reset(converter); }, py::arg("converter"));
+  m.def("ucnv_reset", [](_UConverterPtr &converter) { ucnv_reset(converter); }, py::arg("converter"));
 
   m.def(
       "ucnv_reset_from_unicode", [](_UConverterPtr &converter) { ucnv_resetFromUnicode(converter); },

--- a/src/ucsdet.cpp
+++ b/src/ucsdet.cpp
@@ -31,8 +31,7 @@ void init_ucsdet(py::module &m) {
   //
   // Functions
   //
-  m.def(
-      "ucsdet_close", [](_UCharsetDetectorPtr &ucsd) { ucsdet_close(ucsd); }, py::arg("ucsd"));
+  m.def("ucsdet_close", [](_UCharsetDetectorPtr &ucsd) { ucsdet_close(ucsd); }, py::arg("ucsd"));
 
   m.def(
       "ucsdet_detect",

--- a/src/uenum.cpp
+++ b/src/uenum.cpp
@@ -20,8 +20,7 @@ void init_uenum(py::module &m) {
   //
   // Functions
   //
-  m.def(
-      "uenum_close", [](_UEnumerationPtr &en) { uenum_close(en); }, py::arg("en"));
+  m.def("uenum_close", [](_UEnumerationPtr &en) { uenum_close(en); }, py::arg("en"));
 
   m.def(
       "uenum_count",

--- a/src/ulocdata.cpp
+++ b/src/ulocdata.cpp
@@ -63,8 +63,7 @@ void init_ulocdata(py::module &m) {
   //
   // Functions
   //
-  m.def(
-      "ulocdata_close", [](_ULocaleDataPtr &uld) { ulocdata_close(uld); }, py::arg("uld"));
+  m.def("ulocdata_close", [](_ULocaleDataPtr &uld) { ulocdata_close(uld); }, py::arg("uld"));
 
   m.def("ulocdata_get_cldr_version", []() {
     UVersionInfo version_array;

--- a/src/uniset.cpp
+++ b/src/uniset.cpp
@@ -117,8 +117,7 @@ void init_uniset(py::module &m) {
 
   us.def("__copy__", &UnicodeSet::clone);
 
-  us.def(
-      "__deepcopy__", [](const UnicodeSet &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  us.def("__deepcopy__", [](const UnicodeSet &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   us.def(
         "__eq__", [](const UnicodeSet &self, const UnicodeSet &other) { return self == other; }, py::is_operator(),

--- a/src/unistr.cpp
+++ b/src/unistr.cpp
@@ -20,8 +20,7 @@ void init_unistr(py::module &m, py::class_<Replaceable, UObject> &rep, py::class
   //
   rep.def("__copy__", &Replaceable::clone);
 
-  rep.def(
-      "__deepcopy__", [](const Replaceable &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  rep.def("__deepcopy__", [](const Replaceable &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   rep.def("__len__", &Replaceable::length);
 
@@ -111,8 +110,7 @@ void init_unistr(py::module &m, py::class_<Replaceable, UObject> &rep, py::class
 
   us.def("__copy__", &UnicodeString::clone);
 
-  us.def(
-      "__deepcopy__", [](const UnicodeString &self, py::dict &) { return self.clone(); }, py::arg("memo"));
+  us.def("__deepcopy__", [](const UnicodeString &self, py::dict &) { return self.clone(); }, py::arg("memo"));
 
   us.def(
       "__eq__",

--- a/src/uscript.cpp
+++ b/src/uscript.cpp
@@ -370,8 +370,7 @@ void init_uscript(py::module &m) {
 #endif // (U_ICU_VERSION_MAJOR_NUM >= 49)
 
 #if (U_ICU_VERSION_MAJOR_NUM >= 51)
-  m.def(
-      "uscript_is_cased", [](UScriptCode script) -> py::bool_ { return uscript_isCased(script); }, py::arg("script"));
+  m.def("uscript_is_cased", [](UScriptCode script) -> py::bool_ { return uscript_isCased(script); }, py::arg("script"));
 
   m.def(
       "uscript_is_right_to_left", [](UScriptCode script) -> py::bool_ { return uscript_isRightToLeft(script); },

--- a/src/uscript.cpp
+++ b/src/uscript.cpp
@@ -259,6 +259,9 @@ void init_uscript(py::module &m) {
       .value("USCRIPT_KAWI", USCRIPT_KAWI)
       .value("USCRIPT_NAG_MUNDARI", USCRIPT_NAG_MUNDARI)
 #endif // (U_ICU_VERSION_MAJOR_NUM >= 72)
+#if (U_ICU_VERSION_MAJOR_NUM >= 75)
+      .value("USCRIPT_ARABIC_NASTALIQ", USCRIPT_ARABIC_NASTALIQ, "Aran")
+#endif // (U_ICU_VERSION_MAJOR_NUM >= 75)
 #ifndef U_HIDE_DEPRECATED_API
       .value("USCRIPT_CODE_LIMIT", USCRIPT_CODE_LIMIT,
              "**Deprecated:** ICU 58 The numeric value may change over time, see ICU ticket #12420.")

--- a/src/uspoof.cpp
+++ b/src/uspoof.cpp
@@ -272,8 +272,7 @@ void init_uspoof(py::module &m) {
       },
       py::arg("sc"));
 
-  m.def(
-      "uspoof_close", [](_USpoofCheckerPtr &sc) { uspoof_close(sc); }, py::arg("sc"));
+  m.def("uspoof_close", [](_USpoofCheckerPtr &sc) { uspoof_close(sc); }, py::arg("sc"));
 
 #if (U_ICU_VERSION_MAJOR_NUM >= 58)
   m.def(

--- a/src/usprep.cpp
+++ b/src/usprep.cpp
@@ -42,8 +42,7 @@ void init_usprep(py::module &m) {
   //
   // Functions
   //
-  m.def(
-      "usprep_close", [](_UStringPrepProfilePtr &profile) { usprep_close(profile); }, py::arg("profile"));
+  m.def("usprep_close", [](_UStringPrepProfilePtr &profile) { usprep_close(profile); }, py::arg("profile"));
 
   m.def(
       "usprep_open",

--- a/src/utext.cpp
+++ b/src/utext.cpp
@@ -238,8 +238,7 @@ void init_utext(py::module &m) {
       },
       py::arg("ut"), py::arg("native_start"), py::arg("native_limit"), py::arg("dest_index"), py::arg("move"));
 
-  m.def(
-      "utext_current32", [](_UTextPtr &ut) { return utext_current32(ut); }, py::arg("ut"));
+  m.def("utext_current32", [](_UTextPtr &ut) { return utext_current32(ut); }, py::arg("ut"));
 
   m.def(
       "utext_equals", [](_UTextPtr &a, _UTextPtr &b) -> py::bool_ { return utext_equals(a, b); }, py::arg("a"),
@@ -260,34 +259,28 @@ void init_utext(py::module &m) {
       },
       py::arg("ut"), py::arg("native_start"), py::arg("native_limit"));
 
-  m.def(
-      "utext_freeze", [](_UTextPtr &ut) { utext_freeze(ut); }, py::arg("ut"));
+  m.def("utext_freeze", [](_UTextPtr &ut) { utext_freeze(ut); }, py::arg("ut"));
 
-  m.def(
-      "utext_get_native_index", [](_UTextPtr &ut) { return utext_getNativeIndex(ut); }, py::arg("ut"));
+  m.def("utext_get_native_index", [](_UTextPtr &ut) { return utext_getNativeIndex(ut); }, py::arg("ut"));
 
   m.def(
       "utext_get_previous_native_index", [](_UTextPtr &ut) { return utext_getPreviousNativeIndex(ut); }, py::arg("ut"));
 
-  m.def(
-      "utext_has_meta_data", [](_UTextPtr &ut) -> py::bool_ { return utext_hasMetaData(ut); }, py::arg("ut"));
+  m.def("utext_has_meta_data", [](_UTextPtr &ut) -> py::bool_ { return utext_hasMetaData(ut); }, py::arg("ut"));
 
   m.def(
       "utext_is_length_expensive", [](_UTextPtr &ut) -> py::bool_ { return utext_isLengthExpensive(ut); },
       py::arg("ut"));
 
-  m.def(
-      "utext_is_writable", [](_UTextPtr &ut) -> py::bool_ { return utext_isWritable(ut); }, py::arg("ut"));
+  m.def("utext_is_writable", [](_UTextPtr &ut) -> py::bool_ { return utext_isWritable(ut); }, py::arg("ut"));
 
   m.def(
       "utext_move_index32", [](_UTextPtr &ut, int32_t delta) -> py::bool_ { return utext_moveIndex32(ut, delta); },
       py::arg("ut"), py::arg("delta"));
 
-  m.def(
-      "utext_native_length", [](_UTextPtr &ut) { return utext_nativeLength(ut); }, py::arg("ut"));
+  m.def("utext_native_length", [](_UTextPtr &ut) { return utext_nativeLength(ut); }, py::arg("ut"));
 
-  m.def(
-      "utext_next32", [](_UTextPtr &ut) { return utext_next32(ut); }, py::arg("ut"));
+  m.def("utext_next32", [](_UTextPtr &ut) { return utext_next32(ut); }, py::arg("ut"));
 
   m.def(
       "utext_next32_from", [](_UTextPtr &ut, int64_t native_index) { return utext_next32From(ut, native_index); },
@@ -368,8 +361,7 @@ void init_utext(py::module &m) {
       },
       py::keep_alive<1, 0>(), py::arg("ut"), py::arg("s"), py::arg("length") = -1);
 
-  m.def(
-      "utext_previous32", [](_UTextPtr &ut) { return utext_previous32(ut); }, py::arg("ut"));
+  m.def("utext_previous32", [](_UTextPtr &ut) { return utext_previous32(ut); }, py::arg("ut"));
 
   m.def(
       "utext_previous32_from",

--- a/src/utypes.cpp
+++ b/src/utypes.cpp
@@ -263,11 +263,9 @@ void init_utypes(py::module &m) {
   //
   m.def("u_error_name", &u_errorName, py::arg("code"));
 
-  m.def(
-      "u_failure", [](UErrorCode code) -> py::bool_ { return U_FAILURE(code); }, py::arg("code"));
+  m.def("u_failure", [](UErrorCode code) -> py::bool_ { return U_FAILURE(code); }, py::arg("code"));
 
-  m.def(
-      "u_success", [](UErrorCode code) -> py::bool_ { return U_SUCCESS(code); }, py::arg("code"));
+  m.def("u_success", [](UErrorCode code) -> py::bool_ { return U_SUCCESS(code); }, py::arg("code"));
 
   m.attr("U_MILLIS_PER_DAY") = U_MILLIS_PER_DAY;
   m.attr("U_MILLIS_PER_HOUR") = U_MILLIS_PER_HOUR;

--- a/tests/test_numberformatter.py
+++ b/tests/test_numberformatter.py
@@ -419,6 +419,26 @@ def test_localized_number_formatter_72():
     assert num.to_temp_string() == "2 Metern, 10 Zentimetern"
 
 
+@pytest.mark.skipif(U_ICU_VERSION_MAJOR_NUM < 75, reason="ICU4C<75")
+def test_localized_number_formatter_75():
+    # UnlocalizedNumberFormatter
+    # icu::number::LocalizedNumberFormatter::withoutLocale() const &
+    lnf2 = (
+        NumberFormatter.with_()
+        .notation(Notation.compact_long())
+        .locale("fr")
+        .unit_width(UNumberUnitWidth.UNUM_UNIT_WIDTH_FULL_NAME)
+    )
+    unf2 = lnf2.without_locale()
+    assert isinstance(unf2, UnlocalizedNumberFormatter)
+    f = unf2.unit(MeasureUnit.create_meter())
+    # l1 = f.threshold(0).locale("ja-JP")
+    l1 = f.locale("ja-JP")
+    result1 = l1.format_double(2)
+    actual1 = result1.to_string()
+    assert actual1 == "2 メートル"
+
+
 @pytest.mark.skipif(U_ICU_VERSION_MAJOR_NUM < 62, reason="ICU4C<62")
 def test_localized_number_formatter_to_format():
     # fmt: off

--- a/tests/test_numberrangeformatter.py
+++ b/tests/test_numberrangeformatter.py
@@ -311,6 +311,25 @@ def test_localized_number_range_formatter_64():
     ) == "1 m \u2013 5 m"  # 1 m - 5 m
 
 
+@pytest.mark.skipif(U_ICU_VERSION_MAJOR_NUM < 75, reason="ICU4C<75")
+def test_localized_number_range_formatter_75():
+    # UnlocalizedNumberRangeFormatter
+    # icu::number::LocalizedNumberRangeFormatter::withoutLocale() const &
+    unf2 = (
+        NumberRangeFormatter.with_()
+        .identity_fallback(
+            UNumberRangeIdentityFallback.UNUM_IDENTITY_FALLBACK_RANGE
+        )
+        .locale("ar-EG")
+        .without_locale()
+    )
+    assert isinstance(unf2, UnlocalizedNumberRangeFormatter)
+    res2 = unf2.locale("ja-JP").format_formattable_range(
+        Formattable(5), Formattable(5)
+    )
+    assert res2.to_temp_string() == "5\uFF5E5"
+
+
 def test_number_range_formatter():
     # static UnlocalizedNumberRangeFormatter
     # icu::number::NumberRangeFormatter::with()

--- a/tests/test_tblcoll.py
+++ b/tests/test_tblcoll.py
@@ -807,9 +807,7 @@ def test_sort():
         return (
             -1
             if _result == UCollationResult.UCOL_LESS
-            else 0
-            if _result == UCollationResult.UCOL_EQUAL
-            else 1
+            else 0 if _result == UCollationResult.UCOL_EQUAL else 1
         )
 
     result1 = sorted(src)

--- a/tests/test_ubidi.py
+++ b/tests/test_ubidi.py
@@ -437,9 +437,10 @@ def test_set_line():
     #                        UErrorCode *pErrorCode
     # )
     # void ubidi_close(UBiDi *pBiDi)
-    with gc(ubidi_open_sized(length, 0), ubidi_close) as para, gc(
-        ubidi_open_sized(length, 0), ubidi_close
-    ) as line:
+    with (
+        gc(ubidi_open_sized(length, 0), ubidi_close) as para,
+        gc(ubidi_open_sized(length, 0), ubidi_close) as line,
+    ):
         ubidi_set_para(para, text, -1, UBIDI_DEFAULT_LTR)
         assert ubidi_get_direction(para) == UBiDiDirection.UBIDI_MIXED
 

--- a/tests/test_ubidi.py
+++ b/tests/test_ubidi.py
@@ -437,10 +437,9 @@ def test_set_line():
     #                        UErrorCode *pErrorCode
     # )
     # void ubidi_close(UBiDi *pBiDi)
-    with (
-        gc(ubidi_open_sized(length, 0), ubidi_close) as para,
-        gc(ubidi_open_sized(length, 0), ubidi_close) as line,
-    ):
+    with gc(ubidi_open_sized(length, 0), ubidi_close) as para, gc(
+        ubidi_open_sized(length, 0), ubidi_close
+    ) as line:
         ubidi_set_para(para, text, -1, UBIDI_DEFAULT_LTR)
         assert ubidi_get_direction(para) == UBiDiDirection.UBIDI_MIXED
 

--- a/tests/test_uchar.py
+++ b/tests/test_uchar.py
@@ -241,6 +241,38 @@ def test_u_get_binary_property_set():
     assert uniset.contains(0x3000)  # U+3000: Ideographic Space
 
 
+@pytest.mark.skipif(U_ICU_VERSION_MAJOR_NUM < 75, reason="ICU4C<75")
+def test_u_get_id_types():
+    from icupy.icu import UIdentifierType, u_get_id_types, u_has_id_type
+
+    c = 0x1D1DE
+
+    # int32_t u_getIDTypes (
+    #       UChar32 c,
+    #       UIdentifierType *types,
+    #       int32_t capacity,
+    #       UErrorCode *pErrorCode
+    # )
+    types = u_get_id_types(c)
+    assert isinstance(types, list)
+    assert len(types) == 3
+    types.sort()
+    assert types == [
+        UIdentifierType.U_ID_TYPE_NOT_XID,
+        UIdentifierType.U_ID_TYPE_TECHNICAL,
+        UIdentifierType.U_ID_TYPE_UNCOMMON_USE,
+    ]
+
+    # bool u_hasIDType(
+    #       UChar32 c,
+    #       UIdentifierType type
+    # )
+    assert u_has_id_type(c, UIdentifierType.U_ID_TYPE_NOT_CHARACTER) is False
+    assert u_has_id_type(c, UIdentifierType.U_ID_TYPE_NOT_XID) is True
+    assert u_has_id_type(c, UIdentifierType.U_ID_TYPE_TECHNICAL) is True
+    assert u_has_id_type(c, UIdentifierType.U_ID_TYPE_UNCOMMON_USE) is True
+
+
 @pytest.mark.skipif(U_ICU_VERSION_MAJOR_NUM < 63, reason="ICU4C<63")
 def test_u_get_int_property_map():
     # fmt: off

--- a/tests/test_uspoof.py
+++ b/tests/test_uspoof.py
@@ -358,9 +358,12 @@ def test_api_58():
     # fmt: on
     # USpoofCheckResult *uspoof_openCheckResult(UErrorCode *status)
     # void uspoof_closeCheckResult(USpoofCheckResult *checkResult)
-    with gc(uspoof_open(), uspoof_close) as sc, gc(
-        uspoof_open_check_result(), uspoof_close_check_result
-    ) as check_result:
+    with (
+        gc(uspoof_open(), uspoof_close) as sc,
+        gc(
+            uspoof_open_check_result(), uspoof_close_check_result
+        ) as check_result,
+    ):
         id_ = "m\u0307"
 
         # int32_t uspoof_check2(

--- a/tests/test_uspoof.py
+++ b/tests/test_uspoof.py
@@ -358,12 +358,9 @@ def test_api_58():
     # fmt: on
     # USpoofCheckResult *uspoof_openCheckResult(UErrorCode *status)
     # void uspoof_closeCheckResult(USpoofCheckResult *checkResult)
-    with (
-        gc(uspoof_open(), uspoof_close) as sc,
-        gc(
-            uspoof_open_check_result(), uspoof_close_check_result
-        ) as check_result,
-    ):
+    with gc(uspoof_open(), uspoof_close) as sc, gc(
+        uspoof_open_check_result(), uspoof_close_check_result
+    ) as check_result:
         id_ = "m\u0307"
 
         # int32_t uspoof_check2(

--- a/tests/test_uts46.py
+++ b/tests/test_uts46.py
@@ -149,9 +149,11 @@ _test_cases = [
     [
         "a\\u2260b\\u226Ec\\u226Fd",
         "B",
-        "a\\uFFFDb\\uFFFDc\\uFFFDd"
-        if U_ICU_VERSION_MAJOR_NUM < 74
-        else "a\\u2260b\\u226Ec\\u226Fd",
+        (
+            "a\\uFFFDb\\uFFFDc\\uFFFDd"
+            if U_ICU_VERSION_MAJOR_NUM < 74
+            else "a\\u2260b\\u226Ec\\u226Fd"
+        ),
         IDNA.ERROR_DISALLOWED if U_ICU_VERSION_MAJOR_NUM < 74 else 0,
     ],
     # many deviation characters, test the special mapping code


### PR DESCRIPTION
- Add `icupy.icu.number.LocalizedNumberFormatter.without_locale()`
- Add `icupy.icu.number.LocalizedNumberRangeFormatter.without_locale()`
- Add `icupy.icu.number.SimpleNumber.set_maximum_integer_digits(maximum_integer_digits)`
- Add `icupy.icu.u_get_id_types(c)`
- Add `icupy.icu.u_has_id_type(c, type_)`
- Add `icupy.icu.UIdentifierStatus` enum
- Add `icupy.icu.UIdentifierType` enum
- Add `icupy.icu.UProperty.UCHAR_IDENTIFIER_STATUS`
- Add `icupy.icu.UProperty.UCHAR_IDENTIFIER_TYPE`
- Add `icupy.icu.UScriptCode.USCRIPT_ARABIC_NASTALIQ`