### PR TITLE
Refactor SearchIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Changed
 
 - **Breaking:** update return type of version information functions (#211)
+- **Breaking:** update `icupy.icu.SearchIterator.__next__()` to return tuple of start and end indices instead of start index of match (#224)
+- **Breaking:** update `icupy.icu.SearchIterator.__reversed__()` to return list of `(start, end)` tuples instead of list of start indices of matches (#224)
 - Update return type of `icupy.icu.RuleBasedBreakIterator.get_binary_rules()` (#212)
 - Update return type of `icupy.icu.ResourceBundle.get_binary()` (#213)
 - Update return type of `icupy.icu.UnicodeString.get_buffer()` and `.get_terminated_buffer()` (#215)

--- a/src/stsearch.cpp
+++ b/src/stsearch.cpp
@@ -53,74 +53,210 @@ void init_stsearch(py::module &m) {
   //
   // class icu::SearchIterator
   //
-  py::class_<SearchIterator, UObject, PySearchIterator> si(m, "SearchIterator");
+  py::class_<SearchIterator, UObject, PySearchIterator> si(m, "SearchIterator",
+                                                           R"doc(
+      Abstract base class that provides methods to search for a pattern within
+      a text string.
 
-  si.def(py::init<const PySearchIterator &>(), py::arg("other"))
-      .def(py::init<>())
+      Note:
+          Subclasses must implement the following abstract methods:
+          :meth:`.get_offset`, :meth:`._handle_next`,
+          :meth:`._handle_prev`, and :meth:`.set_offset`.
+
+      See Also:
+          :class:`StringSearch`
+
+      Example:
+
+          .. code-block:: python
+
+              # Search iterator using regular expressions
+              from icupy import icu
+              class RegexSearch(icu.SearchIterator):
+                  def __init__(
+                      self,
+                      regexp: icu.UnicodeString | str,
+                      text: icu.UnicodeString,
+                      flags: int = 0,
+                  ) -> None:
+                      icu.SearchIterator.__init__(self, text)
+                      self._matcher = icu.RegexMatcher(regexp, text, flags)
+                      self._offset = 0
+                  def _handle_next(self, position: int) -> int:
+                      # Forward search logic
+                      if not self._matcher.find(position):
+                          self._set_match_not_found()
+                          return icu.USEARCH_DONE
+                      start = self._matcher.start()
+                      end = self._matcher.end()
+                      self._set_match_start(start)
+                      self._set_match_length(end - start)
+                      self._offset = end
+                      return start
+                  def _handle_prev(self, position: int) -> int:
+                      # Backward search logic
+                      last_start = icu.USEARCH_DONE
+                      last_length = 0
+                      # The RegexMatcher does not support backward searches,
+                      # so it performs a full search.
+                      self._matcher.reset()
+                      while self._matcher.find():
+                          start = self._matcher.start()
+                          end = self._matcher.end()
+                          if end > position:
+                              break
+                          last_start = start
+                          last_length = end - start
+                      if last_start == icu.USEARCH_DONE:
+                          self._set_match_not_found()
+                      else:
+                          self._set_match_start(last_start)
+                          self._set_match_length(last_length)
+                          self._offset = last_start
+                      return last_start
+                  def get_offset(self) -> int:
+                      return self._offset
+                  def set_offset(self, position: int) -> None:
+                      if position < 0 or position > len(self.get_text()):
+                          raise icu.ICUError(icu.U_INDEX_OUTOFBOUNDS_ERROR)
+                      self._offset = position
+
+              text = icu.UnicodeString("Apple 123 Banana 456 Cherry 789")
+              it = RegexSearch("\\d+", text)
+              [text[start:end] for start, end in it]  # ['123', '456', '789']
+              [text[start:end] for start, end in reversed(it)]  # ['789', '456', '123']
+      )doc");
+
+  si.def(py::init<const PySearchIterator &>(), py::arg("other"), R"doc(
+      Initialize a ``SearchIterator`` instance from another ``SearchIterator``.
+      )doc")
+      .def(py::init<>(), R"doc(
+      Initialize a ``SearchIterator`` instance with default values.
+
+      .. important::
+
+          Only available in subclasses.
+      )doc")
       .def(py::init([](const icupy::UnicodeStringVariant &text,
                        std::optional<BreakIterator *> &breakiter) {
              return std::make_unique<PySearchIterator>(
                  icupy::to_unistr(text), breakiter.value_or(nullptr));
            }),
-           py::arg("text"), py::arg("breakiter") = std::nullopt)
+           py::arg("text"), py::arg("breakiter") = std::nullopt, R"doc(
+      Initialize a ``SearchIterator`` instance with the specified text and
+      break iterator.
+
+      .. important::
+
+          Only available in subclasses.
+      )doc")
       .def(py::init([](CharacterIterator &text,
                        std::optional<BreakIterator *> &breakiter) {
              return std::make_unique<PySearchIterator>(
                  text, breakiter.value_or(nullptr));
            }),
-           py::arg("text"), py::arg("breakiter") = std::nullopt);
+           py::arg("text"), py::arg("breakiter") = std::nullopt, R"doc(
+      Initialize a ``SearchIterator`` instance with the specified text and
+      break iterator.
+
+      .. important::
+
+          Only available in subclasses.
+      )doc");
 
   si.def(
       "__eq__",
       [](const SearchIterator &self, const SearchIterator &other) {
         return self == other;
       },
-      py::is_operator(), py::arg("other"));
+      py::is_operator(), py::arg("other"), R"doc(
+      Return *self* == *other*.
+      )doc");
 
-  si.def("__iter__", [](SearchIterator &self) -> SearchIterator & {
-    self.reset();
-    return self;
-  });
+  si.def(
+      "__iter__",
+      [](SearchIterator &self) -> SearchIterator & {
+        self.reset();
+        return self;
+      },
+      R"doc(
+      Return an iterator object.
+
+      See Also:
+          :meth:`.__next__`
+      )doc");
 
   si.def(
       "__ne__",
       [](const SearchIterator &self, const SearchIterator &other) {
         return self != other;
       },
-      py::is_operator(), py::arg("other"));
+      py::is_operator(), py::arg("other"), R"doc(
+      Return *self* != *other*.
+      )doc");
 
-  si.def("__next__", [](SearchIterator &self) {
-    ErrorCode error_code;
-    auto n = self.next(error_code);
-    if (error_code.isFailure()) {
-      throw icupy::ICUError(error_code);
-    } else if (n == USEARCH_DONE) {
-      throw py::stop_iteration();
-    }
-    return n;
-  });
+  si.def(
+      "__next__",
+      [](SearchIterator &self) {
+        ErrorCode error_code;
+        auto index = self.next(error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        } else if (index == USEARCH_DONE) {
+          throw py::stop_iteration();
+        }
+        auto length = self.getMatchedLength();
+        return std::make_tuple(index, index + length);
+      },
+      R"doc(
+      Return a tuple of the starting and ending indices of the next match.
+      )doc");
 
-  si.def("__reversed__", [](SearchIterator &self) {
-    std::vector<int32_t> result;
-    ErrorCode error_code;
-    for (auto n = self.last(error_code); n != USEARCH_DONE;
-         n = self.previous(error_code)) {
-      if (error_code.isFailure()) {
-        throw icupy::ICUError(error_code);
-      }
-      result.push_back(n);
-    }
-    return result;
-  });
+  si.def(
+      "__reversed__",
+      [](SearchIterator &self) {
+        ErrorCode error_code;
+        auto index = self.last(error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        std::vector<std::tuple<int32_t, int32_t>> result;
+        int32_t length;
+        while (index != USEARCH_DONE) {
+          length = self.getMatchedLength();
+          result.push_back(std::make_tuple(index, index + length));
+          index = self.preceding(index, error_code);
+          if (error_code.isFailure()) {
+            throw icupy::ICUError(error_code);
+          }
+        }
+        return result;
+      },
+      R"doc(
+      Return a reversed iterator object.
 
-  si.def("first", [](SearchIterator &self) {
-    ErrorCode error_code;
-    auto result = self.first(error_code);
-    if (error_code.isFailure()) {
-      throw icupy::ICUError(error_code);
-    }
-    return result;
-  });
+      See Also:
+          :meth:`.__iter__`
+          :meth:`.__next__`
+      )doc");
+
+  si.def(
+      "first",
+      [](SearchIterator &self) {
+        ErrorCode error_code;
+        auto result = self.first(error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result;
+      },
+      R"doc(
+      Return the character index of the first match; :attr:`USEARCH_DONE`
+      otherwise.
+
+      If a match is found, the iterator is adjusted so that the current index
+      points to the position of the match.
+      )doc");
 
   si.def(
       "following",
@@ -132,38 +268,211 @@ void init_stsearch(py::module &m) {
         }
         return result;
       },
-      py::arg("position"));
+      py::arg("position"), R"doc(
+      Return the character index of the first match following *position*;
+      :attr:`USEARCH_DONE` otherwise.
 
-  si.def("get_attribute", &SearchIterator::getAttribute, py::arg("attribute"));
+      If a match is found, the iterator is adjusted so that the current index
+      points to the position of the match.
+      )doc");
 
-  si.def("get_break_iterator", &SearchIterator::getBreakIterator);
+  si.def("get_attribute", &SearchIterator::getAttribute, py::arg("attribute"),
+         R"doc(
+      Return the value of the specified search attribute.
 
-  si.def("get_matched_length", &SearchIterator::getMatchedLength);
+      See Also:
+          :meth:`.set_attribute`
+      )doc");
 
-  si.def("get_matched_start", &SearchIterator::getMatchedStart);
+  si.def(
+      "get_break_iterator",
+      [](const SearchIterator &self) -> std::optional<const BreakIterator *> {
+        return self.getBreakIterator();
+      },
+      R"doc(
+      Return the break iterator used by this search iterator.
 
-  si.def("get_matched_text", &SearchIterator::getMatchedText,
-         py::arg("result"));
+      See Also:
+          :meth:`.set_break_iterator`
+      )doc");
 
-  si.def("get_text", &SearchIterator::getText);
+  si.def("get_matched_length", &SearchIterator::getMatchedLength, R"doc(
+      Return the length of the matched text.
 
-  si.def("last", [](SearchIterator &self) {
-    ErrorCode error_code;
-    auto result = self.last(error_code);
-    if (error_code.isFailure()) {
-      throw icupy::ICUError(error_code);
-    }
-    return result;
-  });
+      Note:
+          This call returns a valid result only if one of the calls to
+          :meth:`.first`, :meth:`.next`, :meth:`.previous`, or :meth:`.last`
+          has completed successfully.
 
-  si.def("next", [](SearchIterator &self) {
-    ErrorCode error_code;
-    auto result = self.next(error_code);
-    if (error_code.isFailure()) {
-      throw icupy::ICUError(error_code);
-    }
-    return result;
-  });
+      See Also:
+          :meth:`.first`
+          :meth:`.get_matched_start`
+          :meth:`.get_matched_text`
+          :meth:`.last`
+          :meth:`.next`
+          :meth:`.previous`
+      )doc");
+
+  si.def("get_matched_start", &SearchIterator::getMatchedStart, R"doc(
+      Return the starting index of the matched text.
+
+      Note:
+          This call returns a valid result only if one of the calls to
+          :meth:`.first`, :meth:`.next`, :meth:`.previous`, or :meth:`.last`
+          has completed successfully.
+
+      See Also:
+          :meth:`.first`
+          :meth:`.get_matched_length`
+          :meth:`.get_matched_text`
+          :meth:`.last`
+          :meth:`.next`
+          :meth:`.previous`
+      )doc");
+
+  si.def("get_matched_text", &SearchIterator::getMatchedText, py::arg("result"),
+         R"doc(
+      Copy the matched text into *result*.
+
+      Note:
+          This call returns a valid result only if one of the calls to
+          :meth:`.first`, :meth:`.next`, :meth:`.previous`, or :meth:`.last`
+          has completed successfully.
+
+      See Also:
+          :meth:`.first`
+          :meth:`.last`
+          :meth:`.next`
+          :meth:`.previous`
+      )doc");
+
+  // for docstring only
+  // pybind11 throws RuntimeError if not implemented in Python subclass
+  si.def("get_offset", &SearchIterator::getOffset,
+         R"doc(
+      Return the current index in the text being searched.
+
+      If the iteration has passed the end of the text (or the beginning, in the
+      case of a reverse search), return :attr:`USEARCH_DONE`.
+
+      Important:
+          Subclasses must implement the following abstract methods:
+          :meth:`.get_offset`, :meth:`._handle_next`,
+          :meth:`._handle_prev`, and :meth:`.set_offset`.
+
+      See Also:
+           :meth:`.set_offset`
+      )doc");
+
+  si.def(
+      "get_text",
+      [](const SearchIterator &self) -> const UnicodeString & {
+        return self.getText();
+      },
+      R"doc(
+      Return the text being searched.
+
+      See Also:
+          :meth:`.set_text`
+      )doc");
+
+  // for docstring only
+  // pybind11 throws RuntimeError if not implemented in Python subclass
+  si.def(
+      "_handle_next",
+      [](PySearchIterator &self, int32_t position) {
+        ErrorCode error_code;
+        return self.handleNext(position, error_code);
+      },
+      py::arg("position"),
+      R"doc(
+      Framework method that performs the actual forward search in subclasses.
+
+      If a match is found, the implementation must return an index indicating
+      the start of the match, call :meth:`._set_match_start` with that index as
+      an argument, and call :meth:`._set_match_length` with the number of
+      characters in the target text that make up the matching string as an
+      argument. If no match is found, it must return :attr:`USEARCH_DONE` and
+      call :meth:`._set_match_not_found`.
+
+      Important:
+          Subclasses must implement the following abstract methods:
+          :meth:`.get_offset`, :meth:`._handle_next`,
+          :meth:`._handle_prev`, and :meth:`.set_offset`.
+
+      See Also:
+          :meth:`._handle_prev`
+          :meth:`._set_match_length`
+          :meth:`._set_match_not_found`
+          :meth:`._set_match_start`
+      )doc");
+
+  // for docstring only
+  // pybind11 throws RuntimeError if not implemented in Python subclass
+  si.def(
+      "_handle_prev",
+      [](PySearchIterator &self, int32_t position) {
+        ErrorCode error_code;
+        return self.handlePrev(position, error_code);
+      },
+      py::arg("position"),
+      R"doc(
+      Framework method that performs the actual backward search in subclasses.
+
+      If a match is found, the implementation must return an index indicating
+      the start of the match, call :meth:`._set_match_start` with that index as
+      an argument, and call :meth:`._set_match_length` with the number of
+      characters in the target text that make up the matching string as an
+      argument. If no match is found, it must return :attr:`USEARCH_DONE` and
+      call :meth:`._set_match_not_found`.
+
+      Important:
+          Subclasses must implement the following abstract methods:
+          :meth:`.get_offset`, :meth:`._handle_next`,
+          :meth:`._handle_prev`, and :meth:`.set_offset`.
+
+      See Also:
+          :meth:`._handle_next`
+          :meth:`._set_match_length`
+          :meth:`._set_match_not_found`
+          :meth:`._set_match_start`
+      )doc");
+
+  si.def(
+      "last",
+      [](SearchIterator &self) {
+        ErrorCode error_code;
+        auto result = self.last(error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result;
+      },
+      R"doc(
+      Return the character index of the last match; :attr:`USEARCH_DONE`
+      otherwise.
+
+      If a match is found, the iterator is adjusted so that the current index
+      points to the position of the match.
+      )doc");
+
+  si.def(
+      "next",
+      [](SearchIterator &self) {
+        ErrorCode error_code;
+        auto result = self.next(error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result;
+      },
+      R"doc(
+      Return the character index of the next match; :attr:`USEARCH_DONE`
+      otherwise.
+
+      If a match is found, the iterator is adjusted so that the current index
+      points to the position of the match.
+      )doc");
 
   si.def(
       "preceding",
@@ -175,18 +484,35 @@ void init_stsearch(py::module &m) {
         }
         return result;
       },
-      py::arg("position"));
+      py::arg("position"), R"doc(
+      Return the character index of the first match preceding *position*;
+      :attr:`USEARCH_DONE` otherwise.
 
-  si.def("previous", [](SearchIterator &self) {
-    ErrorCode error_code;
-    auto result = self.previous(error_code);
-    if (error_code.isFailure()) {
-      throw icupy::ICUError(error_code);
-    }
-    return result;
-  });
+      If a match is found, the iterator is adjusted so that the current index
+      points to the position of the match.
+      )doc");
 
-  si.def("reset", &SearchIterator::reset);
+  si.def(
+      "previous",
+      [](SearchIterator &self) {
+        ErrorCode error_code;
+        auto result = self.previous(error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result;
+      },
+      R"doc(
+      Return the character index of the previous match; :attr:`USEARCH_DONE`
+      otherwise.
+
+      If a match is found, the iterator is adjusted so that the current index
+      points to the position of the match.
+      )doc");
+
+  si.def("reset", &SearchIterator::reset, R"doc(
+      Reset the search iterator to the initial state.
+      )doc");
 
   si.def(
       "set_attribute",
@@ -198,7 +524,12 @@ void init_stsearch(py::module &m) {
           throw icupy::ICUError(error_code);
         }
       },
-      py::arg("attribute"), py::arg("value"));
+      py::arg("attribute"), py::arg("value"), R"doc(
+      Set the specified search attribute to the specified value.
+
+      See Also:
+          :meth:`.get_attribute`
+      )doc");
 
   si.def(
       "set_break_iterator",
@@ -209,15 +540,67 @@ void init_stsearch(py::module &m) {
           throw icupy::ICUError(error_code);
         }
       },
-      py::arg("breakiter"));
+      py::arg("breakiter"), R"doc(
+      Set the break iterator to be used by this search iterator.
+
+      ``BreakIterator`` is used to limit the points at which matches are
+      detected. If a match is found but its start or end index does not fall
+      within the boundaries defined by ``BreakIterator``, that match is
+      rejected and the search continues for another match. If *breakiter* is
+      `None`, no breaks are detected.
+
+      See Also:
+          :meth:`.get_break_iterator`
+      )doc");
 
   si.def("_set_match_length", &PySearchIterator::setMatchLength,
-         py::arg("length"));
+         py::arg("length"), R"doc(
+      Set the length of the matched text.
 
-  si.def("_set_match_not_found", &PySearchIterator::setMatchNotFound);
+      Important:
+          :meth:`._handle_next` and :meth:`._handle_prev` of the subclasses
+          must call :meth:`._set_match_length` whenever a match is found within
+          the target text.
+      )doc");
+
+  si.def("_set_match_not_found", &PySearchIterator::setMatchNotFound, R"doc(
+      Set the state of the search iterator to indicate that no match was found.
+
+      Important:
+          :meth:`._handle_next` and :meth:`._handle_prev` of the subclasses
+          must call :meth:`._set_match_not_found` if a match is not found
+          within the target text.
+      )doc");
 
   si.def("_set_match_start", &PySearchIterator::setMatchStart,
-         py::arg("position"));
+         py::arg("position"), R"doc(
+      Set the starting index of the matched text.
+
+      Important:
+          :meth:`._handle_next` and :meth:`._handle_prev` of the subclasses
+          must call :meth:`._set_match_start` whenever a match is found within
+          the target text.
+      )doc");
+
+  // for docstring only
+  // pybind11 throws RuntimeError if not implemented in Python subclass
+  si.def(
+      "set_offset",
+      [](SearchIterator &self, int32_t position) {
+        ErrorCode error_code;
+        self.setOffset(position, error_code);
+      },
+      py::arg("position"), R"doc(
+      Set the current index in the text being searched to *position*.
+
+      Important:
+          Subclasses must implement the following abstract methods:
+          :meth:`.get_offset`, :meth:`._handle_next`,
+          :meth:`._handle_prev`, and :meth:`.set_offset`.
+
+      See Also:
+          :meth:`.get_offset`
+      )doc");
 
   si.def(
         "set_text",
@@ -228,7 +611,15 @@ void init_stsearch(py::module &m) {
             throw icupy::ICUError(error_code);
           }
         },
-        py::arg("text"))
+        py::arg("text"), R"doc(
+      Set the text to be searched.
+
+      The iteration is reset to the start.
+
+      .. seealso::
+
+          :meth:`.get_text`
+      )doc")
       .def(
           "set_text",
           [](SearchIterator &self, const icupy::UnicodeStringVariant &text) {
@@ -238,7 +629,15 @@ void init_stsearch(py::module &m) {
               throw icupy::ICUError(error_code);
             }
           },
-          py::arg("text"));
+          py::arg("text"), R"doc(
+      Set the text to be searched.
+
+      The iteration is reset to the start.
+
+      .. seealso::
+
+          :meth:`.get_text`
+      )doc");
 
   //
   // class icu::StringSearch

--- a/tests/test_stsearch.py
+++ b/tests/test_stsearch.py
@@ -107,7 +107,7 @@ def test_api() -> None:
     assert it.next() == 4
     assert it.next() == icu.USEARCH_DONE
 
-    assert list(it) == [0, 4]
+    assert list(it) == [(0, 4), (4, 8)]
 
     # int32_t icu::SearchIterator::preceding(
     #       int32_t position,
@@ -129,7 +129,7 @@ def test_api() -> None:
     assert it.previous() == 0
     assert it.previous() == icu.USEARCH_DONE
 
-    assert reversed(it) == [4, 0]
+    assert reversed(it) == [(4, 8), (0, 4)]
 
     assert it.get_offset() == 0
     it.set_offset(4)


### PR DESCRIPTION
- Update `SearchIterator.__next__()` to return a tuple of the start and end indices instead of the start index of the match.
- Update `SearchIterator.__reversed__()` to return a list of (start, end) tuples instead of a list of start indices of matches.
- Update return type of `SearchIterator.get_break_iterator()`; `BreakIterator` → `BreakIterator | None`
- Update docstring.
- Improve error handling of `SearchIterator.__reversed__()`.
- Fix `SearchIterator.get_text()` to return a reference to the UnicodeString instead of a copy.