### PR TITLE
Deprecate BreakIterator.DONE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Update `icupy.icu.UnicodeString.get_buffer()` and `.get_terminated_buffer()` to return `memoryview` instead of `ConstChar16Ptr` ([#215])
 - Deprecate `icupy.icu.Transliterator.register_instance()` and `.unregister()` ([#221])
 - Deprecate `icupy.icu.ConstVoidPtr`; use `icupy.icu.UserContext` instead ([#227])
+- Deprecate `icupy.icu.BreakIterator.BreakIterator.DONE` and `icupy.icu.BreakIterator.DONE`; use `UBRK_DONE` instead ([#229])
 - Bump pybind11 from 3.0.2 to 3.0.3 ([#217])
 
 ### Added
@@ -376,3 +377,4 @@ Initial release.
 [#224]: https://github.com/miute/icupy/pull/224
 [#226]: https://github.com/miute/icupy/pull/226
 [#227]: https://github.com/miute/icupy/pull/227
+[#229]: https://github.com/miute/icupy/pull/229

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Python bindings for [ICU4C](https://unicode-org.github.io/icu-docs/apidoc/releas
   bi.set_text(src)
   result = []
   start = bi.first()
-  while (end := bi.next()) != icu.BreakIterator.DONE:
+  while (end := bi.next()) != icu.UBRK_DONE:
       if bi.get_rule_status() != icu.UBRK_WORD_NONE:
           result.append(src[start:end])
       start = end

--- a/src/rbbi.cpp
+++ b/src/rbbi.cpp
@@ -60,7 +60,7 @@ void init_rbbi(py::module &m) {
           ... )
           >>> bi.set_text(src)
           >>> start = bi.first()
-          >>> while (end := bi.next()) != icu.BreakIterator.DONE:
+          >>> while (end := bi.next()) != icu.UBRK_DONE:
           ...     print(src[start:end])
           ...     start = end
           ...
@@ -74,9 +74,9 @@ void init_rbbi(py::module &m) {
           >>> bi = icu.BreakIterator.create_word_instance(icu.ULOC_US)
           >>> src = icu.UnicodeString("Alice was beginning to get very tired of sitting by her sister on the bank.")
           >>> bi.set_text(src)
-          >>> result: list[str] = []
+          >>> result = []
           >>> start = bi.first()
-          >>> while (end := bi.next()) != icu.BreakIterator.DONE:
+          >>> while (end := bi.next()) != icu.UBRK_DONE:
           ...     if bi.get_rule_status() != icu.UBRK_WORD_NONE:
           ...         result.append(src[start:end])
           ...     start = end
@@ -85,12 +85,19 @@ void init_rbbi(py::module &m) {
           ['Alice', 'was', 'beginning', 'to', 'get', 'very', 'tired', 'of', 'sitting', 'by', 'her', 'sister', 'on', 'the', 'bank']
       )doc");
 
+  // TODO: Remove `BreakIterator.DONE` in the future release.
   py::enum_<decltype(BreakIterator::DONE)>(bi, "BreakIterator",
-                                           py::arithmetic())
+                                           py::arithmetic(), R"doc(
+Enum constants for text boundary analysis.
+      )doc")
       .value("DONE", BreakIterator::DONE, R"doc(
              DONE is returned by :meth:`~BreakIterator.previous` and
              :meth:`~BreakIterator.next` after all valid boundaries have been
              returned.
+
+             .. deprecated:: 0.24
+
+                Use :attr:`UBRK_DONE` instead.
              )doc")
       .export_values();
 
@@ -315,7 +322,7 @@ void init_rbbi(py::module &m) {
       offset, and return the current character index of the text.
 
       The value returned is always greater than the offset or the value
-      ``BreakIterator.DONE``.
+      :attr:`UBRK_DONE`.
       )doc");
 
   bi.def_static(
@@ -463,7 +470,7 @@ void init_rbbi(py::module &m) {
          R"doc(
       Set the iterator position to the nth boundary from the current boundary,
       and return the current character index of the text or
-      ``BreakIterator.DONE`` if all boundaries have been returned.
+      :attr:`UBRK_DONE` if all boundaries have been returned.
 
       If *n* is negative, move to the previous boundary; if *n* is positive,
       move to the following boundary.
@@ -471,7 +478,7 @@ void init_rbbi(py::module &m) {
       .def("next", py::overload_cast<>(&BreakIterator::next), R"doc(
       Advance the iterator to the boundary following the current boundary,
       and return the current character index of the text or
-      ``BreakIterator.DONE`` if all boundaries have been returned.
+      :attr:`UBRK_DONE` if all boundaries have been returned.
       )doc");
 
   bi.def("preceding", &BreakIterator::preceding, py::arg("offset"), R"doc(
@@ -479,13 +486,13 @@ void init_rbbi(py::module &m) {
       offset, and return the current character index of the text.
 
       The value returned is always smaller than the offset or the value
-      ``BreakIterator.DONE``.
+      :attr:`UBRK_DONE`.
       )doc");
 
   bi.def("previous", &BreakIterator::previous, R"doc(
       Set the iterator position to the boundary preceding the current boundary,
       and return the current character index of the text or
-      ``BreakIterator.DONE`` if all boundaries have been returned.
+      :attr:`UBRK_DONE` if all boundaries have been returned.
       )doc");
 
   // FIXME: Implement "BreakIterator& BreakIterator::refreshInputText(

--- a/tests/test_filteredbrk.py
+++ b/tests/test_filteredbrk.py
@@ -21,11 +21,11 @@ def test_break_iterator_adopt_text() -> None:
     fbi.adopt_text(it)
     assert fbi.first() == 0
     assert fbi.next() == 11
-    assert fbi.next() == icu.BreakIterator.DONE
+    assert fbi.next() == icu.UBRK_DONE
 
     # fbi.adopt_text(None)
     # assert fbi.first() == 0
-    # assert fbi.next() == icu.BreakIterator.DONE
+    # assert fbi.next() == icu.UBRK_DONE
 
 
 def test_break_iterator_api() -> None:
@@ -50,7 +50,7 @@ def test_break_iterator_api() -> None:
     assert fbi.current() == 6
     assert fbi.next() == 11
     assert fbi.current() == 11
-    assert fbi.next() == icu.BreakIterator.DONE
+    assert fbi.next() == icu.UBRK_DONE
     assert fbi.current() == 11
 
     assert fbi.first() == 0
@@ -242,11 +242,11 @@ def test_filtered_break_iterator_builder_56() -> None:
     assert fbi.next() == 84
     assert fbi.next() == 90
     assert fbi.next() == 278
-    assert fbi.next() == icu.BreakIterator.DONE
+    assert fbi.next() == icu.UBRK_DONE
 
     text2 = icu.UnicodeString()
     fbi.set_text(text2)
-    assert fbi.next() == icu.BreakIterator.DONE
+    assert fbi.next() == icu.UBRK_DONE
 
     # [2]
     # void icu::BreakIterator::setText(
@@ -258,7 +258,7 @@ def test_filtered_break_iterator_builder_56() -> None:
     assert fbi.next() == 84
     assert fbi.next() == 90
     assert fbi.next() == 278
-    assert fbi.next() == icu.BreakIterator.DONE
+    assert fbi.next() == icu.UBRK_DONE
     icu.utext_close(ut)
 
 
@@ -296,4 +296,4 @@ def test_filtered_break_iterator_builder_60() -> None:
     assert fbi.next() == 84
     assert fbi.next() == 90
     assert fbi.next() == 278
-    assert fbi.next() == icu.BreakIterator.DONE
+    assert fbi.next() == icu.UBRK_DONE

--- a/tests/test_rbbi.py
+++ b/tests/test_rbbi.py
@@ -16,11 +16,11 @@ def test_adopt_text() -> None:
     assert bi.next() == 4
     assert bi.next() == 8
     assert bi.next() == 12
-    assert bi.next() == icu.BreakIterator.DONE
+    assert bi.next() == icu.UBRK_DONE
 
     # bi.adopt_text(None)
     # assert bi.first() == 0
-    # assert bi.next() == icu.BreakIterator.DONE
+    # assert bi.next() == icu.UBRK_DONE
 
 
 def test_clone() -> None:
@@ -68,7 +68,7 @@ def test_create_character_instance() -> None:
     assert bi.next() == 10
     assert bi.next() == 11
     assert bi.next() == 12
-    assert bi.next() == icu.BreakIterator.DONE
+    assert bi.next() == icu.UBRK_DONE
 
     assert list(bi) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     assert reversed(bi) == [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
@@ -96,7 +96,7 @@ def test_create_line_instance() -> None:
     assert bi.next() == 4
     assert bi.next() == 8
     assert bi.next() == 12
-    assert bi.next() == icu.BreakIterator.DONE
+    assert bi.next() == icu.UBRK_DONE
 
     assert list(bi) == [4, 8, 12]
     assert reversed(bi) == [12, 8, 4]
@@ -122,7 +122,7 @@ def test_create_sentence_instance() -> None:
 
     assert bi.first() == 0
     assert bi.next() == 12
-    assert bi.next() == icu.BreakIterator.DONE
+    assert bi.next() == icu.UBRK_DONE
 
     assert list(bi) == [12]
     assert reversed(bi) == [12]
@@ -151,7 +151,7 @@ def test_create_title_instance() -> None:
     assert bi.next() == 4
     assert bi.next() == 8
     assert bi.next() == 12
-    assert bi.next() == icu.BreakIterator.DONE
+    assert bi.next() == icu.UBRK_DONE
 
     assert list(bi) == [4, 8, 12]
     assert reversed(bi) == [12, 8, 4]
@@ -182,7 +182,7 @@ def test_create_word_instance() -> None:
     assert bi.next() == 8
     assert bi.next() == 11
     assert bi.next() == 12
-    assert bi.next() == icu.BreakIterator.DONE
+    assert bi.next() == icu.UBRK_DONE
 
     assert list(bi) == [3, 4, 7, 8, 11, 12]
     assert reversed(bi) == [12, 11, 8, 7, 4, 3]
@@ -209,7 +209,7 @@ def test_following() -> None:
     assert bi.following(7) == 8
     assert bi.following(8) == 11
     assert bi.following(11) == 12
-    assert bi.following(12) == icu.BreakIterator.DONE
+    assert bi.following(12) == icu.UBRK_DONE
 
 
 def test_get_available_locales() -> None:
@@ -328,7 +328,7 @@ def test_get_rule_status() -> None:
     assert bi.get_rule_status() == icu.UWordBreak.UBRK_WORD_LETTER
     assert bi.next() == 12
     assert bi.get_rule_status() == icu.UWordBreak.UBRK_WORD_NONE
-    assert bi.next() == icu.BreakIterator.DONE
+    assert bi.next() == icu.UBRK_DONE
 
 
 @pytest.mark.skipif(icu.U_ICU_VERSION_MAJOR_NUM < 52, reason="ICU4C<52")
@@ -501,11 +501,11 @@ def test_next() -> None:
     assert bi.first() == 0
     assert bi.next(3) == 7
     assert bi.next(3) == 12
-    assert bi.next(3) == icu.BreakIterator.DONE
+    assert bi.next(3) == icu.UBRK_DONE
     assert bi.current() == 12
     assert bi.next(-3) == 7
     assert bi.next(-3) == 0
-    assert bi.next(-3) == icu.BreakIterator.DONE
+    assert bi.next(-3) == icu.UBRK_DONE
     assert bi.current() == 0
 
     # [2]
@@ -517,7 +517,7 @@ def test_next() -> None:
     assert bi.next() == 8
     assert bi.next() == 11
     assert bi.next() == 12
-    assert bi.next() == icu.BreakIterator.DONE
+    assert bi.next() == icu.UBRK_DONE
 
 
 def test_operator() -> None:
@@ -563,7 +563,7 @@ def test_preceding() -> None:
     assert bi.preceding(7) == 4
     assert bi.preceding(4) == 3
     assert bi.preceding(3) == 0
-    assert bi.preceding(0) == icu.BreakIterator.DONE
+    assert bi.preceding(0) == icu.UBRK_DONE
 
 
 def test_previous() -> None:
@@ -579,7 +579,7 @@ def test_previous() -> None:
     assert bi.previous() == 4
     assert bi.previous() == 3
     assert bi.previous() == 0
-    assert bi.previous() == icu.BreakIterator.DONE
+    assert bi.previous() == icu.UBRK_DONE
 
 
 def test_rule_based_break_iterator() -> None:
@@ -609,7 +609,7 @@ def test_rule_based_break_iterator() -> None:
     assert bi3.next() == 2
     assert bi3.next() == 3
     assert bi3.next() == 4
-    assert bi3.next() == icu.BreakIterator.DONE
+    assert bi3.next() == icu.UBRK_DONE
     assert bi3.current() == 4
 
     bi3a = icu.RuleBasedBreakIterator(
@@ -625,7 +625,7 @@ def test_rule_based_break_iterator() -> None:
     assert bi3a.next() == 2
     assert bi3a.next() == 3
     assert bi3a.next() == 4
-    assert bi3a.next() == icu.BreakIterator.DONE
+    assert bi3a.next() == icu.UBRK_DONE
     assert bi3a.current() == 4
     assert bi3 == bi3a
 
@@ -644,7 +644,7 @@ def test_rule_based_break_iterator() -> None:
     assert bi4.next() == 2
     assert bi4.next() == 3
     assert bi4.next() == 4
-    assert bi4.next() == icu.BreakIterator.DONE
+    assert bi4.next() == icu.UBRK_DONE
     assert bi4.current() == 4
 
     # [2]
@@ -658,7 +658,7 @@ def test_rule_based_break_iterator() -> None:
     assert bi2.next() == 2
     assert bi2.next() == 3
     assert bi2.next() == 4
-    assert bi2.next() == icu.BreakIterator.DONE
+    assert bi2.next() == icu.UBRK_DONE
     assert bi2.current() == 4
 
     # [5]


### PR DESCRIPTION
Deprecate `BreakIterator.BreakIterator.DONE` and `BreakIterator.DONE`; use `UBRK_DONE` instead.