### PR TITLE
Add rich comparison operators for CollationKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update `icupy.icu.ResourceBundle.get_binary()` to return `memoryview` instead of `bytes` ([#213])
 - Update `icupy.icu.UnicodeString.get_buffer()` and `.get_terminated_buffer()` to return `memoryview` instead of `ConstChar16Ptr` ([#215])
 - Update docstring ([#231])
+- Add rich comparison operators for `icupy.icu.CollationKey` ([#235])
 - Deprecate `icupy.icu.Transliterator.register_instance()` and `.unregister()` ([#221])
 - Deprecate `icupy.icu.ConstVoidPtr`; use `icupy.icu.UserContext` instead ([#227])
 - Deprecate `icupy.icu.BreakIterator.BreakIterator.DONE` and `icupy.icu.BreakIterator.DONE`; use `UBRK_DONE` instead ([#229])
@@ -383,3 +384,4 @@ Initial release.
 [#231]: https://github.com/miute/icupy/pull/231
 [#232]: https://github.com/miute/icupy/pull/232
 [#234]: https://github.com/miute/icupy/pull/234
+[#235]: https://github.com/miute/icupy/pull/235

--- a/src/sortkey.cpp
+++ b/src/sortkey.cpp
@@ -53,10 +53,55 @@ void init_sortkey(py::module &m) {
   ck.def(
       "__eq__",
       [](const CollationKey &self, const CollationKey &other) {
-        return self == other;
+        ErrorCode error_code;
+        auto result = self.compareTo(other, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result == UCOL_EQUAL;
       },
       py::is_operator(), py::arg("other"), R"doc(
       Return *self* == *other*.
+
+      .. note::
+
+         Only bitwise comparisons are performed.
+      )doc");
+
+  ck.def(
+      "__ge__",
+      [](const CollationKey &self, const CollationKey &other) {
+        ErrorCode error_code;
+        auto result = self.compareTo(other, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result == UCOL_GREATER || result == UCOL_EQUAL;
+      },
+      py::is_operator(), py::arg("other"), R"doc(
+      Return *self* >= *other*.
+
+      .. note::
+
+         Only bitwise comparisons are performed.
+      )doc");
+
+  ck.def(
+      "__gt__",
+      [](const CollationKey &self, const CollationKey &other) {
+        ErrorCode error_code;
+        auto result = self.compareTo(other, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result == UCOL_GREATER;
+      },
+      py::is_operator(), py::arg("other"), R"doc(
+      Return *self* > *other*.
+
+      .. note::
+
+         Only bitwise comparisons are performed.
       )doc");
 
   ck.def("__hash__", &CollationKey::hashCode, R"doc(
@@ -66,12 +111,57 @@ void init_sortkey(py::module &m) {
       )doc");
 
   ck.def(
+      "__le__",
+      [](const CollationKey &self, const CollationKey &other) {
+        ErrorCode error_code;
+        auto result = self.compareTo(other, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result == UCOL_LESS || result == UCOL_EQUAL;
+      },
+      py::is_operator(), py::arg("other"), R"doc(
+      Return *self* <= *other*.
+
+      .. note::
+
+         Only bitwise comparisons are performed.
+      )doc");
+
+  ck.def(
+      "__lt__",
+      [](const CollationKey &self, const CollationKey &other) {
+        ErrorCode error_code;
+        auto result = self.compareTo(other, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result == UCOL_LESS;
+      },
+      py::is_operator(), py::arg("other"), R"doc(
+      Return *self* < *other*.
+
+      .. note::
+
+         Only bitwise comparisons are performed.
+      )doc");
+
+  ck.def(
       "__ne__",
       [](const CollationKey &self, const CollationKey &other) {
-        return self != other;
+        ErrorCode error_code;
+        auto result = self.compareTo(other, error_code);
+        if (error_code.isFailure()) {
+          throw icupy::ICUError(error_code);
+        }
+        return result != UCOL_EQUAL;
       },
       py::is_operator(), py::arg("other"), R"doc(
       Return *self* != *other*.
+
+      .. note::
+
+         Only bitwise comparisons are performed.
       )doc");
 
   ck.def(
@@ -88,6 +178,10 @@ void init_sortkey(py::module &m) {
       Return :attr:`~UCollationResult.UCOL_LESS` if *self* < *target*,
       :attr:`~UCollationResult.UCOL_GREATER` if *self* > *target*, and
       :attr:`~UCollationResult.UCOL_EQUAL` otherwise.
+
+      .. note::
+
+         Only bitwise comparisons are performed.
       )doc");
 
   ck.def(


### PR DESCRIPTION
- Replace direct bitwise comparisons with `compareTo`.
- Add `__ge__`, `__gt__`, `__le__`, and `__lt__`.