### PR TITLE
Deprecate UnicodeString.temp_sub_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Deprecate `icupy.icu.Transliterator.register_instance()` and `.unregister()` ([#221])
 - Deprecate `icupy.icu.ConstVoidPtr`; use `icupy.icu.UserContext` instead ([#227])
 - Deprecate `icupy.icu.BreakIterator.BreakIterator.DONE` and `icupy.icu.BreakIterator.DONE`; use `UBRK_DONE` instead ([#229])
+- Deprecate `icupy.icu.UnicodeString.temp_sub_string()` and `.temp_sub_string_between()` ([#238])
 - Bump pybind11 from 3.0.2 to 3.0.4 ([#217], [#234])
 
 ### Added
@@ -389,3 +390,4 @@ Initial release.
 [#235]: https://github.com/miute/icupy/pull/235
 [#236]: https://github.com/miute/icupy/pull/236
 [#237]: https://github.com/miute/icupy/pull/237
+[#238]: https://github.com/miute/icupy/pull/238

--- a/src/unistr.cpp
+++ b/src/unistr.cpp
@@ -2112,15 +2112,22 @@ string.
 #endif // (U_ICU_VERSION_MAJOR_NUM >= 56)
 
   us.def("temp_sub_string", &UnicodeString::tempSubString, py::arg("start") = 0,
-         py::arg("length") = INT32_MAX, R"doc(
+         py::arg("length") = INT32_MAX, py::keep_alive<0, 1>(), R"doc(
       Return a temporary ``UnicodeString`` that is a substring
       *self[start:start + length]* of this ``UnicodeString``.
+
+      .. version-deprecated:: 0.24
+         Do not use this method. It may be removed in a future release.
       )doc");
 
   us.def("temp_sub_string_between", &UnicodeString::tempSubStringBetween,
-         py::arg("start") = 0, py::arg("limit") = INT32_MAX, R"doc(
+         py::arg("start") = 0, py::arg("limit") = INT32_MAX,
+         py::keep_alive<0, 1>(), R"doc(
       Return a temporary ``UnicodeString`` that is a substring
       *self[start:limit]* of this ``UnicodeString``.
+
+      .. version-deprecated:: 0.24
+         Do not use this method. It may be removed in a future release.
       )doc");
 
   us.def(


### PR DESCRIPTION
Deprecate UnicodeString.temp_sub_string() and UnicodeString.temp_sub_string_between().