### PR TITLE
Make locale parameter optional in DateFormat and RuleBasedNumberFormat APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Breaking:** rename the module `icupy.icu.NoUnit` to `icupy.icu.nounit` ([#242])
 - Replace anonymous enum members within a class with class attributes ([#243])
 - Change the base class of the enums from `pybind11_object` to `enum.IntEnum` ([#245])
+- Change the default value of the `locale` parameter in the factory methods of `icupy.icu.DateFormat` and in `icupy.icu.RuleBasedNumberFormat.get_rule_set_display_name()` from `Locale.get_default()` to `None` ([#247])
 
 ### Added
 
@@ -411,3 +412,4 @@ Initial release.
 [#243]: https://github.com/miute/icupy/pull/243
 [#245]: https://github.com/miute/icupy/pull/245
 [#246]: https://github.com/miute/icupy/pull/246
+[#247]: https://github.com/miute/icupy/pull/247

--- a/src/datefmt.cpp
+++ b/src/datefmt.cpp
@@ -64,17 +64,38 @@ order full, long, medium, short.
 
   df.def("clone", &DateFormat::clone);
 
-  df.def_static("create_date_instance", &DateFormat::createDateInstance,
-                py::arg("style") = DateFormat::kDefault,
-                py::arg_v("locale", Locale::getDefault(),
-                          "icupy.icu.Locale.get_default()"));
+  df.def_static(
+      "create_date_instance",
+      [](DateFormat::EStyle style,
+         std::optional<const icupy::LocaleVariant> &locale) {
+        return DateFormat::createDateInstance(
+            style,
+            locale ? icupy::to_locale(locale.value()) : Locale::getDefault());
+      },
+      py::arg("style") = DateFormat::kDefault, py::arg("locale") = std::nullopt,
+      R"doc(
+      Create a new date formatter with the specified date style and locale.
 
-  df.def_static("create_date_time_instance",
-                &DateFormat::createDateTimeInstance,
-                py::arg("date_style") = DateFormat::kDefault,
-                py::arg("time_style") = DateFormat::kDefault,
-                py::arg_v("locale", Locale::getDefault(),
-                          "icupy.icu.Locale.get_default()"));
+      *locale* is not specified, the current default locale is used.
+      )doc");
+
+  df.def_static(
+      "create_date_time_instance",
+      [](DateFormat::EStyle date_style, DateFormat::EStyle time_style,
+         std::optional<const icupy::LocaleVariant> &locale) {
+        return DateFormat::createDateTimeInstance(
+            date_style, time_style,
+            locale ? icupy::to_locale(locale.value()) : Locale::getDefault());
+      },
+      py::arg("date_style") = DateFormat::kDefault,
+      py::arg("time_style") = DateFormat::kDefault,
+      py::arg("locale") = std::nullopt,
+      R"doc(
+      Create a new date-time formatter with the specified date-time styles and
+      locale.
+
+      *locale* is not specified, the current default locale is used.
+      )doc");
 
   df.def_static("create_instance", &DateFormat::createInstance);
 
@@ -110,10 +131,20 @@ order full, long, medium, short.
           py::arg("skeleton"));
 #endif // (U_ICU_VERSION_MAJOR_NUM >= 55)
 
-  df.def_static("create_time_instance", &DateFormat::createTimeInstance,
-                py::arg("style") = DateFormat::kDefault,
-                py::arg_v("locale", Locale::getDefault(),
-                          "icupy.icu.Locale.get_default()"));
+  df.def_static(
+      "create_time_instance",
+      [](DateFormat::EStyle style,
+         std::optional<const icupy::LocaleVariant> &locale) {
+        return DateFormat::createTimeInstance(
+            style,
+            locale ? icupy::to_locale(locale.value()) : Locale::getDefault());
+      },
+      py::arg("style") = DateFormat::kDefault, py::arg("locale") = std::nullopt,
+      R"doc(
+      Create a new time formatter with the specified time style and locale.
+
+      *locale* is not specified, the current default locale is used.
+      )doc");
 
   df.def_static(
       "get_available_locales",

--- a/src/rbnf.cpp
+++ b/src/rbnf.cpp
@@ -305,22 +305,32 @@ Tags for the predefined rulesets.
           "get_rule_set_display_name",
           [](RuleBasedNumberFormat &self,
              const icupy::UnicodeStringVariant &rule_set_name,
-             const icupy::LocaleVariant &locale) {
-            return self.getRuleSetDisplayName(icupy::to_unistr(rule_set_name),
-                                              icupy::to_locale(locale));
+             std::optional<const icupy::LocaleVariant> &locale) {
+            return self.getRuleSetDisplayName(
+                icupy::to_unistr(rule_set_name),
+                locale ? icupy::to_locale(locale.value())
+                       : Locale::getDefault());
           },
-          py::arg("rule_set_name"),
-          py::arg_v("locale", Locale::getDefault(),
-                    "icupy.icu.Locale.get_default()"))
+          py::arg("rule_set_name"), py::arg("locale") = std::nullopt, R"doc(
+      Return the display name of the specified rule set for the specified
+      locale.
+
+      *locale* is not specified, the current default locale is used.
+      )doc")
       .def(
           "get_rule_set_display_name",
           [](RuleBasedNumberFormat &self, int32_t index,
-             const icupy::LocaleVariant &locale) {
-            return self.getRuleSetDisplayName(index, icupy::to_locale(locale));
+             std::optional<const icupy::LocaleVariant> &locale) {
+            return self.getRuleSetDisplayName(
+                index, locale ? icupy::to_locale(locale.value())
+                              : Locale::getDefault());
           },
-          py::arg("index"),
-          py::arg_v("locale", Locale::getDefault(),
-                    "icupy.icu.Locale.get_default()"));
+          py::arg("index"), py::arg("locale") = std::nullopt, R"doc(
+      Return the display name of the rule set with the specified index for the
+      specified locale.
+
+      *locale* is not specified, the current default locale is used.
+      )doc");
 
   rbnf.def(
       "get_rule_set_display_name_locale",

--- a/tests/test_datefmt.py
+++ b/tests/test_datefmt.py
@@ -122,7 +122,12 @@ def test_create_instance() -> None:
         icu.DateFormat.DEFAULT, icu.Locale.get_default()
     )
     assert isinstance(fmt1b, icu.DateFormat)
-    assert fmt1 == fmt1a == fmt1b
+
+    fmt1c = icu.DateFormat.create_date_instance(
+        icu.DateFormat.DEFAULT, str(icu.Locale.get_default())
+    )
+    assert isinstance(fmt1c, icu.DateFormat)
+    assert fmt1 == fmt1a == fmt1b == fmt1c
 
     # static DateFormat *icu::DateFormat::createDateTimeInstance(
     #       EStyle dateStyle = kDefault,
@@ -146,7 +151,14 @@ def test_create_instance() -> None:
         icu.Locale.get_default(),
     )
     assert isinstance(fmt2c, icu.DateFormat)
-    assert fmt2 == fmt2a == fmt2b == fmt2c
+
+    fmt2d = icu.DateFormat.create_date_time_instance(
+        icu.DateFormat.DEFAULT,
+        icu.DateFormat.DEFAULT,
+        str(icu.Locale.get_default()),
+    )
+    assert isinstance(fmt2d, icu.DateFormat)
+    assert fmt2 == fmt2a == fmt2b == fmt2c == fmt2d
 
     # static DateFormat *icu::DateFormat::createInstance(void)
     fmt3 = icu.DateFormat.create_instance()
@@ -171,8 +183,12 @@ def test_create_instance() -> None:
     fmt4b = icu.DateFormat.create_time_instance(
         icu.DateFormat.DEFAULT, icu.Locale.get_default()
     )
-    assert isinstance(fmt4b, icu.DateFormat)
-    assert fmt4 == fmt4a == fmt4b
+
+    fmt4c = icu.DateFormat.create_time_instance(
+        icu.DateFormat.DEFAULT, str(icu.Locale.get_default())
+    )
+    assert isinstance(fmt4c, icu.DateFormat)
+    assert fmt4 == fmt4a == fmt4b == fmt4c
 
 
 @pytest.mark.skipif(icu.U_ICU_VERSION_MAJOR_NUM < 55, reason="ICU4C<55")

--- a/tests/test_rbnf.py
+++ b/tests/test_rbnf.py
@@ -439,6 +439,14 @@ def test_get_rule_set_display_name() -> None:
     assert isinstance(result, icu.UnicodeString)
     assert result in ["%main", "Main", "leMain", "das Main"]
 
+    result = fmt.get_rule_set_display_name("%main", icu.Locale.get_default())
+    assert isinstance(result, icu.UnicodeString)
+    assert result in ["%main", "Main", "leMain", "das Main"]
+
+    result = fmt.get_rule_set_display_name("%main", str(icu.Locale.get_default()))
+    assert isinstance(result, icu.UnicodeString)
+    assert result in ["%main", "Main", "leMain", "das Main"]
+
     result = fmt.get_rule_set_display_name(icu.UnicodeString("%main"), icu.Locale("de_DE_FOO"))
     assert isinstance(result, icu.UnicodeString)
     assert result == "das Main"
@@ -461,6 +469,14 @@ def test_get_rule_set_display_name() -> None:
     #       const Locale &locale = Locale::getDefault()
     # )
     result = fmt.get_rule_set_display_name(0)
+    assert isinstance(result, icu.UnicodeString)
+    assert result in ["%main", "Main", "leMain", "das Main"]
+
+    result = fmt.get_rule_set_display_name(0, icu.Locale.get_default())
+    assert isinstance(result, icu.UnicodeString)
+    assert result in ["%main", "Main", "leMain", "das Main"]
+
+    result = fmt.get_rule_set_display_name(0, str(icu.Locale.get_default()))
     assert isinstance(result, icu.UnicodeString)
     assert result in ["%main", "Main", "leMain", "das Main"]
 


### PR DESCRIPTION
Change the default value of the `locale` parameter in the factory and display name APIs from `Locale.get_default()` to `None`.

Updates:
- DateFormat.create_date_instance()
- DateFormat.create_date_time_instance()
- DateFormat.create_time_instance()
- RuleBasedNumberFormat.get_rule_set_display_name()